### PR TITLE
Add skeleton for the ZBC Solidity library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,33 @@
+BSD 3-Clause Clear License
+
+Copyright © 2022 ZAMA.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+3. Neither the name of ZAMA nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE*.
+THIS SOFTWARE IS PROVIDED BY THE ZAMA AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ZAMA OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*In addition to the rights carried by this license, ZAMA grants to the user a non-exclusive, 
+free and non-commercial license on all patents filed in its name relating to the open-source 
+code (the "Patents") for the sole purpose of evaluation, development, research, prototyping 
+and experimentation.

--- a/contracts/Ciphertext.sol
+++ b/contracts/Ciphertext.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.7.0 <0.9.0;
+
+// A library of functions for managing ciphertexts.
+library Ciphertext {
+
+    // The maximum ciphertext output length in bytes.
+    // Rationale: `bytes` ciphertext layout is 32 bytes of length metadata, followed by 175328 bytes of ciphertext.
+    uint256 constant MaxOutputCiphertextBytesLen = 32 + 175328;
+
+    // Reencrypt the given ciphertext `handle` to the given `publicKey`.
+    // If successful, return the reencrypted ciphertext. Else, fail.
+    // Currently, can only be used in read-only requests. If called on a write request, it will fail.
+    function reencrypt(uint256 handle, bytes memory publicKey) internal view returns (bytes memory ciphertext) {
+        // 32 bytes for the handle + the actual length.
+        uint256 inputLen = 32 + publicKey.length;
+
+        bytes memory input = new bytes(inputLen);
+
+        // Store the handle first.
+        assembly { mstore(add(input, 32), handle) }
+
+        // And then the actual public key.
+        for (uint256 i = 0; i < publicKey.length; i++) {
+            input[i + 32] = publicKey[i];
+        }
+
+        // Call the reencrypt precompile. Skip 32 bytes of lenght metadata for the input `bytes`.
+        assembly {
+            if iszero(staticcall(gas(), 67, add(input, 32), inputLen, ciphertext, MaxOutputCiphertextBytesLen)) {
+                revert(0, 0)
+            }
+        }
+    }
+
+    // Verify the given ciphertext.
+    // If successful, return the handle to it. Else, fail.
+    // It is expected that the ciphertext is serialized such that it contains a zero-knowledge proof of knowledge of the plaintext.
+    function verify(bytes memory ciphertextWithProof) internal view returns (uint256 handle) {
+        bytes32[1] memory output;
+        uint256 inputLen = ciphertextWithProof.length;
+
+        // Call the verify precompile. Skip 32 bytes of lenght metadata for the input `bytes`.
+        assembly {
+            if iszero(staticcall(gas(), 66, add(ciphertextWithProof, 32), inputLen, output, 32)) {
+                revert(0, 0)
+            }
+        }
+
+        // Copy the handle to the output.
+        handle = uint256(output[0]);
+    }
+
+    // Delegate the given ciphertext `handle` for use in the outer scope.
+    // If successful, return. Else, fail.
+    function delegate(uint256 handle) internal view {
+        bytes32[1] memory input;
+        input[0] = bytes32(handle);
+
+        // Call the delegate precompile.
+        assembly {
+            if iszero(staticcall(gas(), 68, input, 32, 0, 0)) {
+                revert(0, 0)
+            }
+        }
+    }
+}

--- a/contracts/Ciphertext.sol
+++ b/contracts/Ciphertext.sol
@@ -2,6 +2,8 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
+import "./Common.sol";
+
 // A library of functions for managing ciphertexts.
 library Ciphertext {
 
@@ -27,8 +29,9 @@ library Ciphertext {
         }
 
         // Call the reencrypt precompile. Skip 32 bytes of lenght metadata for the input `bytes`.
+        uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(staticcall(gas(), 67, add(input, 32), inputLen, ciphertext, MaxOutputCiphertextBytesLen)) {
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, ciphertext, MaxOutputCiphertextBytesLen)) {
                 revert(0, 0)
             }
         }
@@ -42,8 +45,9 @@ library Ciphertext {
         uint256 inputLen = ciphertextWithProof.length;
 
         // Call the verify precompile. Skip 32 bytes of lenght metadata for the input `bytes`.
+        uint256 precompile = Precompiles.Verify;
         assembly {
-            if iszero(staticcall(gas(), 66, add(ciphertextWithProof, 32), inputLen, output, 32)) {
+            if iszero(staticcall(gas(), precompile, add(ciphertextWithProof, 32), inputLen, output, 32)) {
                 revert(0, 0)
             }
         }
@@ -59,8 +63,9 @@ library Ciphertext {
         input[0] = bytes32(handle);
 
         // Call the delegate precompile.
+        uint256 precompile = Precompiles.Delegate;
         assembly {
-            if iszero(staticcall(gas(), 68, input, 32, 0, 0)) {
+            if iszero(staticcall(gas(), precompile, input, 32, 0, 0)) {
                 revert(0, 0)
             }
         }

--- a/contracts/Common.sol
+++ b/contracts/Common.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.7.0 <0.9.0;
+
+// Addresses of precompiled contracts.
+library Precompiles {
+    uint256 public constant Add = 65;
+    uint256 public constant Verify = 66;
+    uint256 public constant Reencrypt = 67;
+    uint256 public constant Delegate = 68;
+}

--- a/contracts/FHEOperations.sol
+++ b/contracts/FHEOperations.sol
@@ -2,8 +2,9 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
-// A library of functions for homomorphic operations on ciphertexts.
+import "./Common.sol";
 
+// A library of functions for homomorphic operations on ciphertexts.
 // NOTE: Currently, all handles refer to ciphertexts of the same type, i.e. an 8-bit integer. This
 // is likely to change in the future.
 library FHEOperations {
@@ -19,8 +20,9 @@ library FHEOperations {
         bytes32[1] memory output;
 
         // Call the add precompile.
+        uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(staticcall(gas(), 65, input, 64, output, 32)) {
+            if iszero(staticcall(gas(), precompile, input, 64, output, 32)) {
                 revert(0, 0)
             }
         }

--- a/contracts/FHEOperations.sol
+++ b/contracts/FHEOperations.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.7.0 <0.9.0;
+
+// A library of functions for homomorphic operations on ciphertexts.
+
+// NOTE: Currently, all handles refer to ciphertexts of the same type, i.e. an 8-bit integer. This
+// is likely to change in the future.
+library FHEOperations {
+
+    // Add the ciphertext behind `handleA` to the ciphertext behind `handleB` and,
+    // if successful, return a handle to the resulting ciphertext. If not successful, fail.
+    // If successful, the resulting handle is automatically verified.
+    function add(uint256 handleA, uint256 handleB) internal view returns (uint256 resultHandle) {
+        bytes32[2] memory input;
+        input[0] = bytes32(handleA);
+        input[1] = bytes32(handleB);
+
+        bytes32[1] memory output;
+
+        // Call the add precompile.
+        assembly {
+            if iszero(staticcall(gas(), 65, input, 64, output, 32)) {
+                revert(0, 0)
+            }
+        }
+
+        // Copy the handle to the output.
+        resultHandle = uint256(output[0]);
+    }
+}


### PR DESCRIPTION
Separate into two sub-libraries:
 * Ciphertext - for managing ciphertexts
 * FHEOperations - for homomorphic operations on ciphertexts

The exposed library functions just dispatch the calls to the respective precompiled contracts.

An attempt is made to make it easy for developers to use the Zama Blockchain through simple and clear interfaces.