### PR TITLE
Introduce the `FheUInt` type

### DIFF
--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -7,8 +7,8 @@ import "./lib/Common.sol";
 import "./lib/FHEOps.sol";
 
 contract EncryptedERC20 {
-    // A mapping from address to a ciphertext handle.
-    mapping(address => uint256) balances;
+    // A mapping from address to an encrypted balance.
+    mapping(address => FheUInt) balances;
 
     // The owner of the contract.
     address internal owner;
@@ -35,7 +35,7 @@ contract EncryptedERC20 {
 
     // Transfers an encrypted amount.
     function _transfer(address from, address to, bytes calldata encryptedAmount) internal {
-        uint256 amount = Ciphertext.verify(encryptedAmount);
+        FheUInt amount = Ciphertext.verify(encryptedAmount);
 
         // Make sure the sender has enough tokens.
         Common.requireCt(FHEOps.lte(amount, balances[from]));

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.13 <0.9.0;
 
 import "./lib/Ciphertext.sol";
 import "./lib/Common.sol";

--- a/lib/Ciphertext.sol
+++ b/lib/Ciphertext.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "./Precompiles.sol";
+import "./Common.sol";
 
 // A library of functions for managing ciphertexts.
 library Ciphertext {
@@ -11,48 +12,48 @@ library Ciphertext {
     // Rationale: `bytes` ciphertext layout is 32 bytes of length metadata, followed by 65544 bytes of ciphertext.
     uint256 constant MaxCiphertextBytesLen = 32 + 65544;
 
-    // Reencrypt the given ciphertext `handle` to the original caller's public key.
-    // If successful, return the reencrypted ciphertext. Else, fail.
+    // Reencrypt the given `ciphertext` to the original caller's public key.
+    // If successful, return the reencrypted ciphertext bytes. Else, fail.
     // Currently, can only be used in `eth_call`. If called in a transaction, it will fail.
-    function reencrypt(uint256 handle) internal view returns (bytes memory ciphertext) {
+    function reencrypt(FheUInt ciphertext) internal view returns (bytes memory reencrypted) {
         bytes32[1] memory input;
-        input[0] = bytes32(handle);
+        input[0] = bytes32(FheUInt.unwrap(ciphertext));
         uint256 inputLen = 32;
-        ciphertext = new bytes(MaxCiphertextBytesLen);
+        reencrypted = new bytes(MaxCiphertextBytesLen);
 
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, ciphertext, MaxCiphertextBytesLen)) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, MaxCiphertextBytesLen)) {
                 revert(0, 0)
             }
         }
     }
 
-    // Verify the given ciphertext.
-    // If successful, return the handle to it. Else, fail.
+    // Verify the proof of the given `ciphertextWithProof`.
+    // If successful, return the ciphertxt. Else, fail.
     // It is expected that the ciphertext is serialized such that it contains a zero-knowledge proof of knowledge of the plaintext.
-    function verify(bytes memory ciphertextWithProof) internal view returns (uint256 handle) {
+    function verify(bytes memory ciphertextWithProof) internal view returns (FheUInt ciphertext) {
         bytes32[1] memory output;
+        uint256 outputLen = 32;
         uint256 inputLen = ciphertextWithProof.length;
 
         // Call the verify precompile. Skip 32 bytes of lenght metadata for the input `bytes`.
         uint256 precompile = Precompiles.Verify;
         assembly {
-            if iszero(staticcall(gas(), precompile, add(ciphertextWithProof, 32), inputLen, output, 32)) {
+            if iszero(staticcall(gas(), precompile, add(ciphertextWithProof, 32), inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
 
-        // Copy the handle to the output.
-        handle = uint256(output[0]);
+        ciphertext = FheUInt.wrap(uint256(output[0]));
     }
 
-    // Delegate the given ciphertext `handle` for use in the outer scope.
+    // Delegate the given `ciphertext` for use in the outer scope.
     // If successful, return. Else, fail.
-    function delegate(uint256 handle) internal view {
+    function delegate(FheUInt ciphertext) internal view {
         bytes32[1] memory input;
-        input[0] = bytes32(handle);
+        input[0] = bytes32(FheUInt.unwrap(ciphertext));
         uint256 inputLen = 32;
 
         // Call the delegate precompile.

--- a/lib/Ciphertext.sol
+++ b/lib/Ciphertext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.13 <0.9.0;
 
 import "./Precompiles.sol";
 import "./Common.sol";

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -4,19 +4,21 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "./Precompiles.sol";
 
+// Represents a ciphertext.
+type FheUInt is uint256;
+
 library Common {
-    // Requires that the ciphertext under the given handle is true.
+    // Requires that the `ciphertext` is true.
     // If true, the runction returns. Otherwise, it reverts.
-    function requireCt(uint256 handle) internal view {
+    function requireCt(FheUInt ciphertext) internal view {
         bytes32[1] memory input;
-        input[0] = bytes32(handle);
-        uint256 inputOutputLen = 32;
-        bytes32[1] memory output;
+        input[0] = bytes32(FheUInt.unwrap(ciphertext));
+        uint256 inputLen = 32;
 
         // Call the require precompile.
         uint256 precompile = Precompiles.Require;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputOutputLen, output, inputOutputLen)) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, 0, 0)) {
                 revert(0, 0)
             }
         }

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.13 <0.9.0;
 
 import "./Precompiles.sol";
 

--- a/lib/FHEOps.sol
+++ b/lib/FHEOps.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.13 <0.9.0;
 
 import "./Precompiles.sol";
 import "./Common.sol";

--- a/lib/FHEOps.sol
+++ b/lib/FHEOps.sol
@@ -3,80 +3,83 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "./Precompiles.sol";
+import "./Common.sol";
 
 // A library of functions for homomorphic operations on ciphertexts.
-// NOTE: Currently, all handles refer to ciphertexts of the same type, i.e. an 8-bit integer. This
+// NOTE: Currently, all ciphertexts are of the same type, i.e. an 4-bit integer. This
 // is likely to change in the future.
 library FHEOps {
 
-    // Add the ciphertext behind `handleA` to the ciphertext behind `handleB` and,
-    // if successful, return a handle to the resulting ciphertext. If not successful, fail.
-    // If successful, the resulting handle is automatically verified.
-    function add(uint256 handleA, uint256 handleB) internal view returns (uint256 resultHandle) {
-        if (handleA == 0) {
-            return handleB;
-        } else if (handleB == 0) {
-            return handleA;
+    // Add ciphertext `a` to ciphertext `b` and, if successful, return the resulting ciphertext.
+    // If not successful, fail.
+    // If successful, the resulting ciphertext is automatically verified.
+    function add(FheUInt a, FheUInt b) internal view returns (FheUInt result) {
+        if (FheUInt.unwrap(a) == 0) {
+            return b;
+        } else if (FheUInt.unwrap(b) == 0) {
+            return a;
         }
         bytes32[2] memory input;
-        input[0] = bytes32(handleA);
-        input[1] = bytes32(handleB);
+        input[0] = bytes32(FheUInt.unwrap(a));
+        input[1] = bytes32(FheUInt.unwrap(b));
+        uint256 inputLen = 64;
 
         bytes32[1] memory output;
+        uint256 outputLen = 32;
 
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, 64, output, 32)) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
 
-        // Copy the handle to the output.
-        resultHandle = uint256(output[0]);
+        result = FheUInt.wrap(uint256(output[0]));
     }
 
-    // Subtract the ciphertext behind `handleB` from the ciphertext behind `handleA` and,
-    // if successful, return a handle to the resulting ciphertext. If not successful, fail.
-    // If successful, the resulting handle is automatically verified.
-    function sub(uint256 handleA, uint256 handleB) internal view returns (uint256 resultHandle) {
+    // Subtract ciphertext `b` from ciphertext `a` and, if successful, return the resulting ciphertext.
+    // If not successful, fail.
+    // If successful, the resulting ciphertext is automatically verified.
+    function sub(FheUInt a, FheUInt b) internal view returns (FheUInt result) {
         bytes32[2] memory input;
-        input[0] = bytes32(handleA);
-        input[1] = bytes32(handleB);
+        input[0] = bytes32(FheUInt.unwrap(a));
+        input[1] = bytes32(FheUInt.unwrap(b));
+        uint256 inputLen = 64;
 
         bytes32[1] memory output;
+        uint256 outputLen = 32;
 
         // Call the subtract precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, 64, output, 32)) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
 
-        // Copy the handle to the output.
-        resultHandle = uint256(output[0]);
+        result = FheUInt.wrap(uint256(output[0]));
     }
 
-    // Evaluate `handleLhs <= handleRhs` on the underlying ciphertexts and,
-    // if successful, return a handle to the resulting ciphertext.
-    // If successful, the resulting handle is automatically verified.
-    function lte(uint256 handleLhs, uint256 handleRhs) internal view returns (uint256 resultHandle) {
+    // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function lte(FheUInt lhs, FheUInt rhs) internal view returns (FheUInt result) {
         bytes32[2] memory input;
-        input[0] = bytes32(handleLhs);
-        input[1] = bytes32(handleRhs);
+        input[0] = bytes32(FheUInt.unwrap(lhs));
+        input[1] = bytes32(FheUInt.unwrap(rhs));
+        uint256 inputLen = 64;
 
         bytes32[1] memory output;
+        uint256 outputLen = 32;
 
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, 64, output, 32)) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
 
-        // Copy the handle to the output.
-        resultHandle = uint256(output[0]);
+        result = FheUInt.wrap(uint256(output[0]));
     }
 }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.8.13 <0.9.0;
 
 // Addresses of precompiled contracts.
 library Precompiles {


### PR DESCRIPTION
Use a dedicated `FheUInt ` type that wraps uint256 instead of a plain uint256. Helps with readability and type safety.

Remove explicit references to ciphertext handles.