### PR TITLE
Add a blind auction example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 decrypt/target
 decrypt/ciphertexts
+.venv

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -70,8 +70,9 @@ contract BlindAuction {
     function withdraw() public {
         require(auctionStopped);
         FHEUInt bidValue = bids[msg.sender];
-        // TODO: Maybe we should now allow a highest bidder to withdraw?
-        Common.requireCt(FHEOps.lte(bidValue, highestBid));
+        if (!objectClaimed) {
+            Common.requireCt(FHEOps.lt(bidValue, highestBid));
+        }
         tokenContract.transfer(msg.sender, bidValue);
         bids[msg.sender] = FHEUInt.wrap(0);
     }

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.8.13 <0.9.0;
+
+import "../lib/Ciphertext.sol";
+import "../lib/Common.sol";
+import "../lib/FHEOps.sol";
+
+import "./EncryptedERC20.sol";
+
+contract BlindAuction {
+    // The owner of the auction (this) contract.
+    address public auctionOwner;
+
+    // Current highest bid.
+    FHEUInt internal highestBid;
+    // Mapping from bidder to their bid value.
+    mapping(address => FHEUInt) internal bids;
+
+    // The token contract used for encrypted bids.
+    EncryptedERC20 public tokenContract;
+
+    // Whether the auction has stopped. Bids are accepted until it has stopped.
+    bool public auctionStopped;
+
+    // Whether the auction object has been claimed. We need that for a tie-break when
+    // multiple bidders have the same value - in that case, the first one wins.
+    bool public objectClaimed;
+
+    event Winner(address who);
+
+    constructor(EncryptedERC20 _tokenContract) {
+        auctionOwner = msg.sender;
+        tokenContract = _tokenContract;
+        auctionStopped = false;
+        objectClaimed = false;
+    }
+
+    // Bid an `encryptedValue`.
+    function bid(bytes calldata encryptedValue) public {
+        require(!auctionStopped);
+        FHEUInt value = Ciphertext.verify(encryptedValue);
+        bids[msg.sender] = value;
+        if (FHEUInt.unwrap(highestBid) == 0) {
+            highestBid = value;
+        } else {
+            highestBid = FHEOps.cmux(FHEOps.lte(highestBid, value), value, highestBid);
+        }
+        tokenContract.transferFrom(msg.sender, address(this), value);
+    }
+
+    // Returns an encrypted value of 0 or 1 under the caller's public key, indicating
+    // if the caller has the highest bid.
+    function doIHaveHighestBid() public view returns (bytes memory) {
+        require(auctionStopped);
+        return Ciphertext.reencrypt(FHEOps.lte(highestBid, bids[msg.sender]));
+    }
+
+    // Claim the object. Succeeds only if the caller has the highest bid.
+    function claim() public {
+        require(auctionStopped);
+        require(!objectClaimed);
+        Common.requireCt(FHEOps.lte(highestBid, bids[msg.sender]));
+        objectClaimed = true;
+        // TODO: For now, just emit an event indicating who won.
+        emit Winner(msg.sender);
+    }
+
+    // Withdraw a bid from the auction to the caller once the auction has stopped.
+    function withdraw() public {
+        require(auctionStopped);
+        FHEUInt bidValue = bids[msg.sender];
+        // TODO: Maybe we should now allow a highest bidder to withdraw?
+        Common.requireCt(FHEOps.lte(bidValue, highestBid));
+        tokenContract.transfer(msg.sender, bidValue);
+        bids[msg.sender] = FHEUInt.wrap(0);
+    }
+
+    // Stops the auction. No more bids will be accepted.
+    function stopAuction() public onlyAuctionOwner {
+        auctionStopped = true;
+    }
+
+    modifier onlyAuctionOwner() {
+        require(msg.sender == auctionOwner);
+        _;
+    }
+}

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -35,7 +35,12 @@ contract EncryptedERC20 {
 
     // Transfers an encrypted amount from the message sender address to the `to` address.
     function transfer(address to, bytes calldata encryptedAmount) public {
-        _transfer(msg.sender, to, Ciphertext.verify(encryptedAmount));
+        transfer(to, Ciphertext.verify(encryptedAmount));
+    }
+
+    // Transfers an amount from the message sender address to the `to` address.
+    function transfer(address to, FHEUInt amount) public {
+        _transfer(msg.sender, to, amount);
     }
 
     function getTotalSupply() public view returns (bytes memory) {
@@ -61,10 +66,14 @@ contract EncryptedERC20 {
         return Ciphertext.reencrypt(_allowance(owner, spender));
     }
 
-    // Sends `encryptedAmount` tokens using the caller's allowance.
+    // Transfers `encryptedAmount` tokens using the caller's allowance.
     function transferFrom(address from, address to, bytes calldata encryptedAmount) public {
+        transferFrom(from, to, Ciphertext.verify(encryptedAmount));
+    }
+
+    // Transfers `amount` tokens using the caller's allowance.
+    function transferFrom(address from, address to, FHEUInt amount) public {
         address spender = msg.sender;
-        FHEUInt amount = Ciphertext.verify(encryptedAmount);
         _updateAllowance(from, spender, amount);
         _transfer(from, to, amount);
     }

--- a/lib/FHEOps.sol
+++ b/lib/FHEOps.sol
@@ -106,6 +106,28 @@ library FHEOps {
         result = FHEUInt.wrap(uint256(output[0]));
     }
 
+    // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function lt(FHEUInt lhs, FHEUInt rhs) internal view returns (FHEUInt result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(FHEUInt.unwrap(lhs));
+        input[1] = bytes32(FHEUInt.unwrap(rhs));
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the lt precompile.
+        uint256 precompile = Precompiles.LessThan;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = FHEUInt.wrap(uint256(output[0]));
+    }
+
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -12,4 +12,5 @@ library Precompiles {
     uint256 public constant LessThanOrEqual = 70;
     uint256 public constant Subtract = 71;
     uint256 public constant Multiply = 72;
+    uint256 public constant LessThan = 73;
 }


### PR DESCRIPTION
The `BlindAuction` example contract supports a blind auction with the following properties:
 * bids remain hidden
 * winning bid remains hidden
 * winner address becomes public at the end

In order to support hidden bids, we link the auction to the `EncryptedERC20` contract, such that bids are in this token. We utilize the allowances mechanism to approve use of user tokens on their behalf by the auction contract.

The flow is:
1. Auction owner creates the auction contract.
2. Users approve use of tokens in the ERC20 contract via `approve()`.
3. Users call `bid()` to bid an amount less than or equal to the approved token amount.
4. Auction owner stops the auction.
5. Users can call `doIHaveHighestBid() to know if they have the highest bid.
6. If user has highest bid, they can call `claim()` to claim the object. At that point, we decrypt a boolean that shows whether the caller has the highest bid. No other decryptions are done.
7. If user doesn't have the highest bid, they can `withdraw()` their bid.

Currently, we emit an event to denote that the winner has claimed the "object" of the auction.

If two or more bidders bid the same value, whoever claims first is the winner. All other bidders can only withdraw their bids at that point.