### PR TITLE
Add support for the `rand` precompile

### DIFF
--- a/examples/Rand.sol
+++ b/examples/Rand.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.8.13 <0.9.0;
+
+import "../lib/Ciphertext.sol";
+import "../lib/Common.sol";
+import "../lib/FHEOps.sol";
+
+// Shows the rand precompile in Solidity.
+contract Rand {
+    FHEUInt internal value;
+
+    function rand() public {
+        value = FHEOps.rand();
+    }
+
+    function getValue() public view returns (bytes memory) {
+        return Ciphertext.reencrypt(value);
+    }
+}

--- a/lib/FHEOps.sol
+++ b/lib/FHEOps.sol
@@ -173,4 +173,20 @@ library FHEOps {
 
         result = FHEUInt.wrap(uint256(addOutput[0]));
     }
+
+    // Return a random value. The value itself is encrypted.
+    function rand() internal view returns (FHEUInt result) {
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the rand precompile.
+        uint256 precompile = Precompiles.Rand;
+        assembly {
+            if iszero(staticcall(gas(), precompile, 0, 0, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = FHEUInt.wrap(uint256(output[0]));
+    }
 }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -13,4 +13,5 @@ library Precompiles {
     uint256 public constant Subtract = 71;
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
+    uint256 public constant Rand = 74;
 }


### PR DESCRIPTION
Expose the `rand` precompile as `FHEOps.rand()`. It returns a handle to a ciphertext that encrypts a random value. The returned ciphertext and handle are deterministic and can be used on-chain.

Add an example contract that shows how the `rand` precompile works.