### PR TITLE
Add support for optimistic ciphertext requires

### DIFF
--- a/examples/OptimisticRequire.sol
+++ b/examples/OptimisticRequire.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.8.13 <0.9.0;
+
+import "../lib/Ciphertext.sol";
+import "../lib/Common.sol";
+import "../lib/FHEOps.sol";
+
+// Example use of optimistic ciphertext requires. Aims to show the different gas usage
+// as compared to syncrhonous non-optimistic and plaintext ones.
+contract OptimisticRequire {
+    FHEUInt internal ct1;
+    FHEUInt internal ct2;
+    uint256 internal value;
+    uint256 internal iterations;
+
+    function init(bytes calldata ctBytes, uint256 _iterations) public {
+        ct1 = Ciphertext.verify(ctBytes);
+        ct2 = Ciphertext.verify(ctBytes);
+        iterations = _iterations;
+        value = 1;
+    }
+
+    function doWorkToPayGas() internal {
+        uint256 newValue = value;
+        for (uint256 i = 0; i < iterations; i++) {
+            newValue += 2;
+        }
+        value = newValue;
+    }
+
+    function getValue() public view returns(uint256) {
+        return value;
+    }
+
+    // Charge full gas as both requires are true.
+    function optimisticRequireCtTrue() public {
+        // True.
+        Common.optimisticRequireCt(FHEOps.lte(ct1, ct2));
+
+        // True.
+        Common.optimisticRequireCt(FHEOps.lte(ct1, ct2));
+
+        // Mutate state to pay for gas.
+        doWorkToPayGas();
+    }
+
+    // Charge full gas as we are using optimistic requires.
+    function optimisticRequireCtFalse() public {
+        // True.
+        Common.optimisticRequireCt(FHEOps.lte(ct1, ct2));
+
+        // False.
+        Common.optimisticRequireCt(FHEOps.lt(ct1, ct2));
+
+        // Mutate state to pay for gas - we will pay for it, because we are using optimistic requires.
+        doWorkToPayGas();
+    }
+
+    // Charge less than full gas, because the non-optimistic ciphertext require aborts early.
+    function requireCtFalse() public {
+        // True.
+        Common.requireCt(FHEOps.lte(ct1, ct2));
+
+        // False.
+        Common.requireCt(FHEOps.lt(ct1, ct2));
+
+        // Try to mutate state to pay for gas - we won't reach that point due to the false require.
+        doWorkToPayGas();
+    }
+
+    // Must behave as requireCtFalse() in terms of gas.
+    // Since gas estimation would always fail, call it without it by providing a gas value and observe transaction gas usage.
+    function requireFalse() public {
+        // False.
+        require(false);
+
+        // Try to mutate state to pay for gas - we won't reach that point due to the false require.
+        doWorkToPayGas();
+    }
+}

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -23,4 +23,30 @@ library Common {
             }
         }
     }
+
+    // Optimistically requires that the `ciphertext` is true.
+    //
+    // This function does not evaluate the given `ciphertext` at the time of the call.
+    // Instead, it accumulates all optimistic requires and evaluates a single combined
+    // require at the end through the decryption oracle. A side effect of this mechanism
+    // is that a method call with a failed optimistic require will always incur the full
+    // gas cost, as if all optimistic requires were true. Yet, the transaction will be
+    // reverted at the end if any of the optimisic requires were false.
+    //
+    // The benefit of optimistic requires is that they are faster than non-optimistic ones,
+    // because there is a single call to the decryption oracle per transaction, irrespective
+    // of how many optimistic requires were used.
+    function optimisticRequireCt(FHEUInt ciphertext) internal view {
+        bytes32[1] memory input;
+        input[0] = bytes32(FHEUInt.unwrap(ciphertext));
+        uint256 inputLen = 32;
+
+        // Call the optimistic require precompile.
+        uint256 precompile = Precompiles.OptimisticRequire;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, 0, 0)) {
+                revert(0, 0)
+            }
+        }
+    }
 }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -14,4 +14,5 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant Rand = 74;
+    uint256 public constant OptimisticRequire = 75;
 }


### PR DESCRIPTION
Expose the `optimisticRequireCt()` precompile as a library call. See its description for details on how it works.

Add example use of optimistic ciphertext requires with the aim of showing the different gas usage as compared to syncrhonous non-optimistic and plaintext ones.