### PR TITLE
Add support for classical re-encryption of ciphertexts

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -279,10 +279,10 @@ library Impl {
         return 0;
     }
 
-    function reencrypt(uint256 ciphertext, uint256 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
-        input[1] = bytes32(publicKey);
+        input[1] = publicKey;
         uint256 inputLen = 64;
 
         reencrypted = new bytes(reencryptedSize);
@@ -432,7 +432,7 @@ to_print="""
         return euint{i}.wrap(Impl.verify(ciphertext, Common.euint{i}_t));
     }}
 
-    function reencrypt(euint{i} ciphertext, uint256 publicKey) internal view returns (bytes memory reencrypted) {{
+    function reencrypt(euint{i} ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {{
         return Impl.reencrypt(euint{i}.unwrap(ciphertext), publicKey);
     }}
 

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -54,9 +54,7 @@ import "./Common.sol";
 import "./Precompiles.sol";
 
 library Impl {
-    uint256 constant euint8Size = 32 + 28124;
-    uint256 constant euint16Size = 32 + 56236;
-    uint256 constant euint32Size = 32 + 112460;
+    uint256 constant reencryptedSize = 32 + 48 + 4; // 32 bytes for the `byte` type header + 48 bytes for the NaCl anonymous box overhead + 4 bytes for the plaintext value 
 
     function add(uint256 a, uint256 b) internal view returns (uint256 result) {
         if (a == 0) {
@@ -281,22 +279,13 @@ library Impl {
         return 0;
     }
 
-    function reencrypt(uint256 ciphertext, uint8 _type) internal view returns (bytes memory reencrypted) {
-        bytes32[1] memory input;
+    function reencrypt(uint256 ciphertext, uint256 publicKey) internal view returns (bytes memory reencrypted) {
+        bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
-        uint256 inputLen = 32;
+        input[1] = bytes32(publicKey);
+        uint256 inputLen = 64;
 
-        uint256 maxCiphertextBytesLen;
-        if (_type == Common.euint8_t) {
-            maxCiphertextBytesLen = euint8Size;
-        } else if (_type == Common.euint16_t) {
-            maxCiphertextBytesLen = euint16Size;
-        } else if (_type == Common.euint32_t) {
-            maxCiphertextBytesLen = euint32Size;
-        } else {
-            revert("unsupported ciphertext type");
-        }
-        reencrypted = new bytes(maxCiphertextBytesLen);
+        reencrypted = new bytes(reencryptedSize);
 
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
@@ -308,7 +297,7 @@ library Impl {
                     input,
                     inputLen,
                     reencrypted,
-                    maxCiphertextBytesLen
+                    reencryptedSize
                 )
             ) { 
                 revert(0, 0)
@@ -443,8 +432,8 @@ to_print="""
         return euint{i}.wrap(Impl.verify(ciphertext, Common.euint{i}_t));
     }}
 
-    function reencrypt(euint{i} ciphertext) internal view returns (bytes memory reencrypted) {{
-        return Impl.reencrypt(euint{i}.unwrap(ciphertext), Common.euint{i}_t);
+    function reencrypt(euint{i} ciphertext, uint256 publicKey) internal view returns (bytes memory reencrypted) {{
+        return Impl.reencrypt(euint{i}.unwrap(ciphertext), publicKey);
     }}
 
     function delegate(euint{i} ciphertext) internal view {{

--- a/demo_test.py
+++ b/demo_test.py
@@ -4,36 +4,38 @@ from eth_account.signers.local import LocalAccount
 from web3.middleware import construct_sign_and_send_raw_middleware
 from solcx import compile_standard, install_solc
 import json
-import msgpack
-import requests
-import secrets
 import time
 import os
+import sha3
+from eip712_structs import EIP712Struct, Bytes
+from eip712_structs import make_domain
+from nacl.public import PrivateKey, SealedBox
+from coincurve import PrivateKey as ccsk
 
 def transfer(contract, to, account, amount):
+	#TODO: use public key encryption instead
+	os.system("tfhe encrypt {} ck ~/.evmosd/zama/keys/network-fhe-keys/cks.bin bin ./ciphertext.bin".format(amount))
+
+	file = open('./ciphertext.bin',mode='rb')
+	input = file.read()
+	file.close()
+	print('Input len =', len(input))
+
+	# estimate gas and send a mint transaction.
+	print("estimating gas and sending mint transaction...")
 	start = time.time()
-	if with_proofs == True:
-		url_enc = "http://13.39.73.89:23042/encrypt_and_prove"
-		packed = msgpack.packb(amount)
-
-		headers = {"Content-Type": "application/msgpack"}
-
-		enc_response = requests.post(url_enc, data=packed, headers=headers)
-		if enc_response.status_code != 200:
-			raise SystemError()
-		input = enc_response.content
-	else:
-		input = secrets.token_bytes(1024 * 1024 * 20)
-
-	print('Received transaction input from ZKPoK server in %s seconds' % (time.time() - start))
-
-	# print('Input len =', len(input))
+	gas = contract.functions.transfer(to, input).estimate_gas({
+		'value': 0,
+		'from': account.address
+	})
+	print('transfer gas estimation =', gas)
+	print('transfer gas estimation took %s seconds' % (time.time() - start))
 
 	print("Sending transfer transaction...")
 	start = time.time()
 	tx = contract.functions.transfer(to, input).transact({
 		'value': 0,
-		'from': account.address
+		'from': account.address,
 	})
 	transaction_hash = tx.hex()
 	print('Transfer transaction hash: ', transaction_hash)
@@ -44,48 +46,84 @@ def transfer(contract, to, account, amount):
 	print('Mining transfer transaction took %s seconds' % (time.time() - start))
 	assert transaction_receipt['status'] == 1
 
-def reencrypt(contract, account, cks_file, ct_file, expected):
+def reencrypt(contract, account: LocalAccount, ct_file, expected):
+	print("Generating keys...")
+	sk = PrivateKey.generate()
+
+	domain = make_domain(name='Naraggara',
+							version='1',
+							chainId=9000,
+							verifyingContract=contract.address)
+
+	class Reencrypt(EIP712Struct):
+		publicKey = Bytes(32)
+
+	msg = Reencrypt()
+	msg['publicKey'] = sk.public_key._public_key
+	print(sk.public_key._public_key.hex())
+	print(len(sk.public_key._public_key))
+
+	signable_bytes = msg.signable_bytes(domain)
+
+	msg_hash = sha3.keccak_256(signable_bytes).digest()
+	msg_sig = account.signHash(msg_hash)
+	print(msg_sig.r)
+
 	print("Retrieving encrypted balance from chain...")
 	start = time.time()
 
-	ct = contract.functions.balanceOf().call({
+	box = contract.functions.balanceOf(sk.public_key._public_key, msg_sig.v, msg_sig.r.to_bytes(32, 'big'), msg_sig.s.to_bytes(32, 'big')).call({
 		'from': account.address
 	})
-	# print('len(ct) =', len(ct))
+
+	print(box.hex())
+
+	print('len(box) =', len(box))
 	print('retrieving alice\'s balance took %s seconds' % (time.time() - start))
 
-	f = open("{}".format(ct_file), "w+b")
-	f.write(ct)
+	f = open(ct_file, "w+b")
+	f.write(box)
 	f.close()
 
-	res = os.system("decrypt/target/release/decrypt {} {} {}".format(cks_file, ct_file, expected))
-	assert res == 0
+	unseal_box = SealedBox(sk)
+	plaintext = unseal_box.decrypt(box)
+	pt_int = int.from_bytes(plaintext, 'big')
+	print(pt_int)
+	assert pt_int == expected
 
-w3 = Web3(Web3.HTTPProvider('http://13.39.43.100:8545', request_kwargs={'timeout': 600}))
+w3 = Web3(Web3.HTTPProvider('http://localhost:8545', request_kwargs={'timeout': 600}))
 
-alice_private_key = "0x00468d407f31211e8f8fba671fa714be5ea3b1203c683dd999075b28f3eff2fd"
+alice_private_key = "0x245c9e930978f2964492fac9234d1224682699d7783bd7eeeab9274444c0002b"
 alice_account: LocalAccount = Account.from_key(alice_private_key)
+print("Alice address : ")
+print(alice_account.address)
 w3.middleware_onion.add(construct_sign_and_send_raw_middleware(alice_account))
+
+
 
 # bob_private_key = "0x04554c46d10b234939a611dfa3df14d167e4e725ec59e4f38a9bf1177a05ce8f"
 # bob_account: LocalAccount = Account.from_key(bob_private_key)
 # w3.middleware_onion.add(construct_sign_and_send_raw_middleware(bob_account))
 
-carol_private_key = "0xa6c13a4776aee43e5b4da33acc30fa0a688f3271a46357b349d443b2d491f4b2"
+carol_private_key = "0xdd336495d840ab71fa9d76678aa6c84745cb29bb1a1447e1e0816ba2ca8a7c3b"
 carol_account: LocalAccount = Account.from_key(carol_private_key)
+print("Carol address : ")
+print(carol_account.address)
 w3.middleware_onion.add(construct_sign_and_send_raw_middleware(carol_account))
 
 # Change below to match chain specific information:
 chain_id = 9000
-private_key = '0xC7F4542D2E3221D94001A6621299F820F1966BC32ED0937E70283AF54931B19C' # private key of the default account
+private_key = 'C7D1EB4E9FFCC24DBE43150EC404E23B46C1A050F15326BAE7A146C5FC9F1604' # private key of the default account
 account: LocalAccount = Account.from_key(private_key)
+print("Main address: ")
+print(account.address)
 
 print("\n\n======== STEP 1: COMPILE AND DEPLOY SMART CONTRACT ========")
 
 print("Compiling EncryptedERC20.sol...")
 start = time.time()
 
-with open("./examples/EncryptedERC20.sol", "r") as file:
+with open("types/examples/EncryptedERC20.sol", "r") as file:
     file_contents = file.read()
 
 install_solc('0.8.13')
@@ -136,35 +174,24 @@ print(f"contract deployed at {transaction_receipt.contractAddress}")
 print('contract deployment took %s seconds' % (time.time() - start))
 assert transaction_receipt['status'] == 1
 
-print("\n\n======== STEP 2: MINT 2 TOKENS ========")
+print("\n\n======== STEP 2: MINT 1337 TOKENS ========")
 
 # get contract adress and send mint transaction
 contract_address = transaction_receipt.contractAddress
-
-with_proofs = True
 
 # create the contract and make sure we use a middleware to automatically sign calls.
 contract = w3.eth.contract(address=contract_address, abi=abi)
 w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
 
-start = time.time()
+# encrypt amount to mint
+# TODO: use public key encryption heres
+os.system("tfhe encrypt 1337 ck ~/.evmosd/zama/keys/network-fhe-keys/cks.bin bin ./ciphertext.bin")
 
-if with_proofs == True:
-	url_enc = "http://13.39.73.89:23042/encrypt_and_prove"
-	packed = msgpack.packb(2)
+file = open('./ciphertext.bin',mode='rb')
+input = file.read()
+file.close()
 
-	headers = {"Content-Type": "application/msgpack"}
-
-	enc_response = requests.post(url_enc, data=packed, headers=headers)
-	if enc_response.status_code != 200:
-		raise SystemError()
-	input = enc_response.content
-else:
-	input = secrets.token_bytes(1024 * 1024 * 20)
-
-print('Received transaction input from ZKPoK server in %s seconds' % (time.time() - start))
-
-# print('Input len =', len(input))
+print('Input len =', len(input))
 
 # estimate gas and send a mint transaction.
 print("estimating gas and sending mint transaction...")
@@ -189,27 +216,8 @@ transaction_receipt = w3.eth.wait_for_transaction_receipt(transaction_hash)
 print('mint transaction took %s seconds' % (time.time() - start))
 assert transaction_receipt['status'] == 1
 
-print("\n\n======== STEP 3: TRANSFER 2 TOKENS TO ALICE ========")
-transfer(contract, alice_account.address, account, 2)
+print("\n\n======== STEP 3: TRANSFER 5 TOKENS FROM MAIN TO ALICE ========")
+transfer(contract, alice_account.address, account, 5)
 
-print("\n\n======== STEP 4: ALICE REENCRYPTS HER BALANCE ========")
-reencrypt(contract, alice_account, "decrypt/keys/alice_cks.hex", "decrypt/ciphertexts/step4_ct", 2)
-
-print("\n\n======== STEP 5: ALICE SENDS 1 TOKEN TO CAROL ========")
-transfer(contract, carol_account.address, alice_account, 1)
-
-print("\n\n======== STEP 6: ALICE REENCRYPTS HER BALANCE ========")
-reencrypt(contract, alice_account, "decrypt/keys/alice_cks.hex", "decrypt/ciphertexts/step6_ct", 1)
-
-print("\n\n======== STEP 7: CAROL REENCRYPTS HER BALANCE ========")
-reencrypt(contract, carol_account, "decrypt/keys/carol_cks.hex", "decrypt/ciphertexts/step7_ct", 1)
-
-print("\n\n======== STEP 8: CAROL SENDS BACK 1 TOKEN TO ALICE ========")
-transfer(contract, alice_account.address, carol_account, 1)
-
-print("\n\n======== STEP 9: ALICE REENCRYPTS HER BALANCE ========")
-reencrypt(contract, alice_account, "decrypt/keys/alice_cks.hex", "decrypt/ciphertexts/step9_ct", 2)
-
-print("\n\n======== STEP 10: CAROL REENCRYPTS HER BALANCE ========")
-reencrypt(contract, carol_account, "decrypt/keys/carol_cks.hex", "decrypt/ciphertexts/step10_ct", 0)
-
+print("\n\n======== STEP 4: MAIN REENCRYPTS ITS BALANCE ========")
+reencrypt(contract, account, "/Users/louist/.evmosd/ct_to_decrypt.bin", 1332)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ msgpack_python==0.5.6
 py_solc_x==1.1.1
 requests==2.28.1
 web3==5.31.3
+pynacl==1.5.0
+coincurve==18.0.0
+eip712-structs==1.1.0
+eth_utils==0.12.0

--- a/types/examples/EncryptedERC20.sol
+++ b/types/examples/EncryptedERC20.sol
@@ -2,18 +2,18 @@
 
 pragma solidity >=0.8.13 <0.9.0;
 
-import "../lib/Ciphertext.sol";
-import "../lib/Common.sol";
-import "../lib/FHEOps.sol";
+import "types/lib/Ciphertext.sol";
+import "types/lib/Common.sol";
+import "types/lib/FHEOps.sol";
 
 contract EncryptedERC20 {
-    euint32 public totalSupply;
+    euint32 private totalSupply;
     string public constant name = "Naraggara"; // City of Zama's battle
     string public constant symbol = "NARA";
     uint8 public constant decimals = 18;
 
     // used for output authorization
-    bytes32 public domainHash;
+    bytes32 private DOMAIN_SEPARATOR;
 
     // A mapping from address to an encrypted balance.
     mapping(address => euint32) internal balances;
@@ -27,20 +27,24 @@ contract EncryptedERC20 {
     constructor() {
         contractOwner = msg.sender;
 
-        uint chainId;
+        uint256 chainId;
         assembly {
             chainId := chainid()
         }
 
-        domainHash = keccak256(
+        address verifyingContract = address(this);
+
+        DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256(
-                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    abi.encodePacked(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    )
                 ),
                 keccak256(bytes(name)),
-                keccak256(bytes("1")),
+                keccak256("1"),
                 chainId,
-                address(this)
+                verifyingContract
             )
         );
     }
@@ -62,34 +66,60 @@ contract EncryptedERC20 {
         _transfer(msg.sender, to, amount);
     }
 
-    function getTotalSupply() public view returns (bytes memory) {
-        return Ciphertext.reencrypt(totalSupply); // Should be decrypt later
+    function getReencryptHash(
+        bytes32 publicKey
+    ) private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(
+                        abi.encode(
+                            keccak256(
+                                abi.encodePacked("Reencrypt(bytes32 publicKey)")
+                            ),
+                            publicKey
+                        )
+                    )
+                )
+            );
+    }
+
+    function getTotalSupply(
+        bytes32 publicKey,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public view onlyContractOwner returns (bytes memory) {
+        bytes32 reencryptHash = getReencryptHash(publicKey);
+        address signer = ecrecover(reencryptHash, v, r, s);
+        require(signer != address(0), "Invalid EIP712 signature");
+        require(
+            signer == msg.sender,
+            "EIP712 signer and transaction signer do not match"
+        );
+
+        return Ciphertext.reencrypt(totalSupply, publicKey);
     }
 
     // Returns the balance of the caller under their public FHE key.
     // The FHE public key is automatically determined based on the origin of the call.
     function balanceOf(
-        string calldata publicKey,
+        bytes32 publicKey,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) public view returns (bytes memory) {
-        bytes32 reencryptHash = keccak256(
-            abi.encode("Reencrypt(string publicKey)", publicKey)
-        );
-
-        bytes32 signedMessage = keccak256(
-            abi.encodePacked("\x19\x01", domainHash, reencryptHash)
-        );
-
-        address signer = ecrecover(signedMessage, v, r, s);
+        bytes32 reencryptHash = getReencryptHash(publicKey);
+        address signer = ecrecover(reencryptHash, v, r, s);
         require(signer != address(0), "Invalid EIP712 signature");
         require(
             signer == msg.sender,
             "EIP712 signer and transaction signer do not match"
-        ); // safety measure
+        );
 
-        return Ciphertext.reencrypt(balances[signer]);
+        return Ciphertext.reencrypt(balances[signer], publicKey);
     }
 
     // Sets the `encryptedAmount` as the allowance of `spender` over the caller's tokens.
@@ -100,9 +130,19 @@ contract EncryptedERC20 {
 
     // Returns the remaining number of tokens that `spender` is allowed to spend
     // on behalf of the caller. The returned ciphertext is under the caller public FHE key.
-    function allowance(address spender) public view returns (bytes memory) {
+    function allowance(
+        address spender,
+        bytes32 publicKey,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public view returns (bytes memory) {
         address owner = msg.sender;
-        return Ciphertext.reencrypt(_allowance(owner, spender));
+        return
+            Ciphertext.reencrypt(
+                _allowance(owner, spender),
+                0xbeaa8482018de9188aaef8a3ada5c3dcccb2d0d265797f5a0dec484057b554b9
+            );
     }
 
     // Transfers `encryptedAmount` tokens using the caller's allowance.

--- a/types/lib/Ciphertext.sol
+++ b/types/lib/Ciphertext.sol
@@ -11,9 +11,10 @@ library Ciphertext {
     }
 
     function reencrypt(
-        euint8 ciphertext
+        euint8 ciphertext,
+        uint256 publicKey
     ) internal view returns (bytes memory reencrypted) {
-        return Impl.reencrypt(euint8.unwrap(ciphertext), Common.euint8_t);
+        return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
 
     function delegate(euint8 ciphertext) internal view {
@@ -35,9 +36,10 @@ library Ciphertext {
     }
 
     function reencrypt(
-        euint16 ciphertext
+        euint16 ciphertext,
+        uint256 publicKey
     ) internal view returns (bytes memory reencrypted) {
-        return Impl.reencrypt(euint16.unwrap(ciphertext), Common.euint16_t);
+        return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
 
     function delegate(euint16 ciphertext) internal view {
@@ -59,9 +61,10 @@ library Ciphertext {
     }
 
     function reencrypt(
-        euint32 ciphertext
+        euint32 ciphertext,
+        uint256 publicKey
     ) internal view returns (bytes memory reencrypted) {
-        return Impl.reencrypt(euint32.unwrap(ciphertext), Common.euint32_t);
+        return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }
 
     function delegate(euint32 ciphertext) internal view {

--- a/types/lib/Ciphertext.sol
+++ b/types/lib/Ciphertext.sol
@@ -12,7 +12,7 @@ library Ciphertext {
 
     function reencrypt(
         euint8 ciphertext,
-        uint256 publicKey
+        bytes32 publicKey
     ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
@@ -37,7 +37,7 @@ library Ciphertext {
 
     function reencrypt(
         euint16 ciphertext,
-        uint256 publicKey
+        bytes32 publicKey
     ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
@@ -62,7 +62,7 @@ library Ciphertext {
 
     function reencrypt(
         euint32 ciphertext,
-        uint256 publicKey
+        bytes32 publicKey
     ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }

--- a/types/lib/Ciphertext.sol
+++ b/types/lib/Ciphertext.sol
@@ -20,6 +20,14 @@ library Ciphertext {
         Impl.delegate(euint8.unwrap(ciphertext));
     }
 
+    function requireCt(euint8 ciphertext) internal view {
+        Impl.requireCt(euint8.unwrap(ciphertext));
+    }
+
+    function optimisticRequireCt(euint8 ciphertext) internal view {
+        Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
+    }
+
     function asEuint16(
         bytes memory ciphertext
     ) internal view returns (euint16) {
@@ -34,6 +42,14 @@ library Ciphertext {
 
     function delegate(euint16 ciphertext) internal view {
         Impl.delegate(euint16.unwrap(ciphertext));
+    }
+
+    function requireCt(euint16 ciphertext) internal view {
+        Impl.requireCt(euint16.unwrap(ciphertext));
+    }
+
+    function optimisticRequireCt(euint16 ciphertext) internal view {
+        Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
     function asEuint32(
@@ -52,39 +68,11 @@ library Ciphertext {
         Impl.delegate(euint32.unwrap(ciphertext));
     }
 
-    function requireCt(euint8 ciphertext) internal view {
-        {
-            Impl.requireCt(euint8.unwrap(ciphertext));
-        }
-    }
-
-    function requireCt(euint16 ciphertext) internal view {
-        {
-            Impl.requireCt(euint16.unwrap(ciphertext));
-        }
-    }
-
     function requireCt(euint32 ciphertext) internal view {
-        {
-            Impl.requireCt(euint32.unwrap(ciphertext));
-        }
-    }
-
-    function optimisticRequireCt(euint8 ciphertext) internal view {
-        {
-            Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
-        }
-    }
-
-    function optimisticRequireCt(euint16 ciphertext) internal view {
-        {
-            Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
-        }
+        Impl.requireCt(euint32.unwrap(ciphertext));
     }
 
     function optimisticRequireCt(euint32 ciphertext) internal view {
-        {
-            Impl.optimisticRequireCt(euint32.unwrap(ciphertext));
-        }
+        Impl.optimisticRequireCt(euint32.unwrap(ciphertext));
     }
 }

--- a/types/lib/Common.sol
+++ b/types/lib/Common.sol
@@ -7,7 +7,7 @@ type euint16 is uint256;
 type euint32 is uint256;
 
 library Common {
-    // Values used to communicate types to the runtime.
+    // Values used to communicate types at runtime to the cast() precompile.
     uint8 internal constant euint8_t = 0;
     uint8 internal constant euint16_t = 1;
     uint8 internal constant euint32_t = 2;

--- a/types/lib/Impl.sol
+++ b/types/lib/Impl.sol
@@ -318,11 +318,11 @@ library Impl {
 
     function reencrypt(
         uint256 ciphertext,
-        uint256 publicKey
+        bytes32 publicKey
     ) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
-        input[1] = bytes32(publicKey);
+        input[1] = publicKey;
         uint256 inputLen = 64;
 
         reencrypted = new bytes(reencryptedSize);

--- a/types/lib/Impl.sol
+++ b/types/lib/Impl.sol
@@ -6,9 +6,7 @@ import "./Common.sol";
 import "./Precompiles.sol";
 
 library Impl {
-    uint256 constant euint8Size = 32 + 28124;
-    uint256 constant euint16Size = 32 + 56236;
-    uint256 constant euint32Size = 32 + 112460;
+    uint256 constant reencryptedSize = 32 + 48 + 4; // 32 bytes for the `byte` type header + 48 bytes for the NaCl anonymous box overhead + 4 bytes for the plaintext value
 
     function add(uint256 a, uint256 b) internal view returns (uint256 result) {
         if (a == 0) {
@@ -320,23 +318,14 @@ library Impl {
 
     function reencrypt(
         uint256 ciphertext,
-        uint8 _type
+        uint256 publicKey
     ) internal view returns (bytes memory reencrypted) {
-        bytes32[1] memory input;
+        bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
-        uint256 inputLen = 32;
+        input[1] = bytes32(publicKey);
+        uint256 inputLen = 64;
 
-        uint256 maxCiphertextBytesLen;
-        if (_type == Common.euint8_t) {
-            maxCiphertextBytesLen = euint8Size;
-        } else if (_type == Common.euint16_t) {
-            maxCiphertextBytesLen = euint16Size;
-        } else if (_type == Common.euint32_t) {
-            maxCiphertextBytesLen = euint32Size;
-        } else {
-            revert("unsupported ciphertext type");
-        }
-        reencrypted = new bytes(maxCiphertextBytesLen);
+        reencrypted = new bytes(reencryptedSize);
 
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
@@ -348,7 +337,7 @@ library Impl {
                     input,
                     inputLen,
                     reencrypted,
-                    maxCiphertextBytesLen
+                    reencryptedSize
                 )
             ) {
                 revert(0, 0)

--- a/types/lib/Impl.sol
+++ b/types/lib/Impl.sol
@@ -292,6 +292,7 @@ library Impl {
         uint256 ciphertext,
         uint8 toType
     ) internal view returns (uint256) {
+        revert("casting not supported yet");
         bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
         uint256 inputLen = input.length;
 


### PR DESCRIPTION
Updates the `reencrypt` logic to use the features introduced in https://github.com/zama-ai/go-ethereum/pull/95.
End-to-end script updated to use [libsodium](https://pynacl.readthedocs.io/en/latest/) for re-encryption.
Closes #30.