### PR TITLE
Remove the cast and delegate precompiles

### DIFF
--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -7,7 +7,7 @@ type euint16 is uint256;
 type euint32 is uint256;
 
 library Common {
-    // Values used to communicate types at runtime to the cast() precompile.
+    // Values used to communicate types to the runtime.
     uint8 internal constant euint8_t = 0;
     uint8 internal constant euint16_t = 1;
     uint8 internal constant euint32_t = 2;

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -6,7 +6,9 @@ import "./Common.sol";
 import "./Precompiles.sol";
 
 library Impl {
-    uint256 constant reencryptedSize = 32 + 48 + 4; // 32 bytes for the `byte` type header + 48 bytes for the NaCl anonymous box overhead + 4 bytes for the plaintext value
+    // 32 bytes for the `byte` type header + 48 bytes for the NaCl anonymous
+    // box overhead + 4 bytes for the plaintext value.
+    uint256 constant reencryptedSize = 32 + 48 + 4;
 
     function add(uint256 a, uint256 b) internal view returns (uint256 result) {
         if (a == 0) {
@@ -25,16 +27,7 @@ library Impl {
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -59,16 +52,7 @@ library Impl {
         // Call the sub precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -93,16 +77,7 @@ library Impl {
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -112,10 +87,7 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -127,16 +99,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -146,10 +109,7 @@ library Impl {
 
     // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lt(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -161,16 +121,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -181,11 +132,7 @@ library Impl {
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.
-    function cmux(
-        uint256 control,
-        uint256 ifTrue,
-        uint256 ifFalse
-    ) internal view returns (uint256 result) {
+    function cmux(uint256 control, uint256 ifTrue, uint256 ifFalse) internal view returns (uint256 result) {
         // result = (ifTrue - ifFalse) * control + ifFalse
 
         bytes32[2] memory input;
@@ -198,16 +145,7 @@ library Impl {
         uint256 precompile = Precompiles.Subtract;
         bytes32[1] memory subOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    subOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, subOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -218,16 +156,7 @@ library Impl {
         precompile = Precompiles.Multiply;
         bytes32[1] memory mulOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    mulOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, mulOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -238,23 +167,14 @@ library Impl {
         precompile = Precompiles.Add;
         bytes32[1] memory addOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    addOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, addOutput, outputLen)) {
                 revert(0, 0)
             }
         }
 
         result = uint256(addOutput[0]);
     }
-
+    
     // Optimistically requires that the `ciphertext` is true.
     //
     // This function does not evaluate the given `ciphertext` at the time of the call.
@@ -281,45 +201,7 @@ library Impl {
         }
     }
 
-    //    function safeAdd(uint256 a, uint256 b) internal view returns (uint256) {
-    //        TODO: Call addSafe() precompile.
-    //        return 0;
-    //    }
-
-    function cast(
-        uint256 ciphertext,
-        uint8 toType
-    ) internal view returns (uint256) {
-        revert("casting not supported yet");
-        bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
-        uint256 inputLen = input.length;
-
-        bytes32[1] memory output;
-        uint256 outputLen = 32;
-
-        // Call the cast precompile.
-        uint256 precompile = Precompiles.Cast;
-        assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    add(input, 32), // jump over the 32-bit `size` field of the `bytes` data structure to read actual bytes
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
-                revert(0, 0)
-            }
-        }
-        return 0;
-    }
-
-    function reencrypt(
-        uint256 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
         input[1] = publicKey;
@@ -330,16 +212,7 @@ library Impl {
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    reencrypted,
-                    reencryptedSize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, reencryptedSize)) {
                 revert(0, 0)
             }
         }
@@ -358,34 +231,12 @@ library Impl {
         // Call the cast precompile.
         uint256 precompile = Precompiles.Verify;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    add(input, 32), // jump over the 32-bit `size` field of the `bytes` data structure to read actual bytes
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
         result = uint256(output[0]);
-    }
-
-    function delegate(uint256 ciphertext) internal view {
-        bytes32[1] memory input;
-        input[0] = bytes32(ciphertext);
-        uint256 inputLen = 32;
-
-        // Call the delegate precompile
-        uint256 precompile = Precompiles.Delegate;
-        assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, 0, 0)) {
-                revert(0, 0)
-            }
-        }
     }
 
     function requireCt(uint256 ciphertext) internal view {

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -2,8 +2,8 @@
 
 pragma solidity >=0.8.13 <0.9.0;
 
-import "lib/Common.sol";
-import "lib/Impl.sol";
+import "./Common.sol";
+import "./Impl.sol";
 
 library TFHE {
     function add(euint8 a, euint8 b) internal view returns (euint8) {
@@ -66,88 +66,24 @@ library TFHE {
         return euint32.wrap(Impl.lt(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint8 a,
-        euint8 b
-    ) internal view returns (euint8) {
-        return
-            euint8.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint8.unwrap(a),
-                    euint8.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.cmux(euint8.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint16 a,
-        euint16 b
-    ) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint16.unwrap(a),
-                    euint16.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.cmux(euint8.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint32 a,
-        euint32 b
-    ) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint32.unwrap(a),
-                    euint32.unwrap(b)
-                )
-            );
-    }
-
-    function toEuint8(euint16 v) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint16.unwrap(v), Common.euint16_t));
-    }
-
-    function toEuint8(euint32 v) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint32.unwrap(v), Common.euint32_t));
-    }
-
-    function toEuint16(euint8 v) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint8.unwrap(v), Common.euint8_t));
-    }
-
-    function toEuint16(euint32 v) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint32.unwrap(v), Common.euint32_t));
-    }
-
-    function toEuint32(euint8 v) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint8.unwrap(v), Common.euint8_t));
-    }
-
-    function toEuint32(euint16 v) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint16.unwrap(v), Common.euint16_t));
+    function cmux(euint8 control, euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.cmux(euint8.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
     }
 
     function asEuint8(bytes memory ciphertext) internal view returns (euint8) {
         return euint8.wrap(Impl.verify(ciphertext, Common.euint8_t));
     }
 
-    function reencrypt(
-        euint8 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint8 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
-    }
-
-    function delegate(euint8 ciphertext) internal view {
-        Impl.delegate(euint8.unwrap(ciphertext));
     }
 
     function requireCt(euint8 ciphertext) internal view {
@@ -158,21 +94,12 @@ library TFHE {
         Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
     }
 
-    function asEuint16(
-        bytes memory ciphertext
-    ) internal view returns (euint16) {
+    function asEuint16(bytes memory ciphertext) internal view returns (euint16) {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
-    function reencrypt(
-        euint16 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint16 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
-    }
-
-    function delegate(euint16 ciphertext) internal view {
-        Impl.delegate(euint16.unwrap(ciphertext));
     }
 
     function requireCt(euint16 ciphertext) internal view {
@@ -183,21 +110,12 @@ library TFHE {
         Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
-    function asEuint32(
-        bytes memory ciphertext
-    ) internal view returns (euint32) {
+    function asEuint32(bytes memory ciphertext) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
     }
 
-    function reencrypt(
-        euint32 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint32 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
-    }
-
-    function delegate(euint32 ciphertext) internal view {
-        Impl.delegate(euint32.unwrap(ciphertext));
     }
 
     function requireCt(euint32 ciphertext) internal view {


### PR DESCRIPTION
Rationale is that cast is not yet supported and delegate is obsolete.

Furthermore, add a few minor style fixes.