### PR TITLE
Add support for the fhePubKey precompile

### DIFF
--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -10,6 +10,9 @@ library Impl {
     // box overhead + 4 bytes for the plaintext value.
     uint256 constant reencryptedSize = 32 + 48 + 4;
 
+    // 32 bytes for the `byte` header + 16553 bytes of key data.
+    uint256 constant fhePubKeySize = 32 + 16553;
+
     function add(uint256 a, uint256 b) internal view returns (uint256 result) {
         if (a == 0) {
             return b;
@@ -305,6 +308,27 @@ library Impl {
                     inputLen,
                     reencrypted,
                     reencryptedSize
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+    }
+
+    function fhePubKey() internal view returns (bytes memory key) {
+        key = new bytes(fhePubKeySize);
+
+        // Call the fhePubKey precompile.
+        uint256 precompile = Precompiles.FhePubKey;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    0,
+                    0,
+                    key,
+                    fhePubKeySize
                 )
             ) {
                 revert(0, 0)

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -6,6 +6,7 @@ library Precompiles {
     uint256 public constant Add = 65;
     uint256 public constant Verify = 66;
     uint256 public constant Reencrypt = 67;
+    uint256 public constant FhePubKey = 68;
     uint256 public constant Require = 69;
     uint256 public constant LessThanOrEqual = 70;
     uint256 public constant Subtract = 71;

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -171,4 +171,9 @@ library TFHE {
     function optimisticRequireCt(euint32 ciphertext) internal view {
         Impl.optimisticRequireCt(euint32.unwrap(ciphertext));
     }
+
+    // Returns the network public FHE key.
+    function fhePubKey() internal view returns (bytes memory) {
+        return Impl.fhePubKey();
+    }
 }


### PR DESCRIPTION
Expose as the fhePubKey() function in TFHE.sol.

Part of https://github.com/zama-ai/go-ethereum/issues/107.