### PR TITLE
feat(precompile): add trivial encrypt

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -37,6 +37,7 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant TrivialEncrypt = 76;
 }
 """
 )
@@ -309,6 +310,36 @@ library Impl {
         result = uint256(output[0]);
     }
 
+    function trivialEncrypt(
+        uint256 value,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(value), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the trivialEncrypt precompile.
+        uint256 precompile = Precompiles.TrivialEncrypt;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
     function requireCt(uint256 ciphertext) internal view {
         bytes32[1] memory input;
         input[0] = bytes32(ciphertext);
@@ -366,6 +397,10 @@ for i in (2**p for p in range(3, 6)):
 to_print="""
     function asEuint{i}(bytes memory ciphertext) internal view returns (euint{i}) {{
         return euint{i}.wrap(Impl.verify(ciphertext, Common.euint{i}_t));
+    }}
+
+    function asEuint{i}(uint256 value) internal view returns (euint{i}) {{
+        return euint{i}.wrap(Impl.trivialEncrypt(value, Common.euint{i}_t));
     }}
 
     function reencrypt(euint{i} ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {{

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -37,7 +37,7 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
-    uint256 public constant TrivialEncrypt = 76;
+    uint256 public constant TrivialEncrypt = 77;
 }
 """
 )

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -321,16 +321,7 @@ library Impl {
         // Call the fhePubKey precompile.
         uint256 precompile = Precompiles.FhePubKey;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    0,
-                    0,
-                    key,
-                    fhePubKeySize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, 0, 0, key, fhePubKeySize)) {
                 revert(0, 0)
             }
         }
@@ -348,6 +339,36 @@ library Impl {
 
         // Call the cast precompile.
         uint256 precompile = Precompiles.Verify;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
+    function trivialEncrypt(
+        uint256 value,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(value), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the trivialEncrypt precompile.
+        uint256 precompile = Precompiles.TrivialEncrypt;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
             if iszero(

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -13,5 +13,5 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
-    uint256 public constant TrivialEncrypt = 76;
+    uint256 public constant TrivialEncrypt = 77;
 }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -13,4 +13,5 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant TrivialEncrypt = 76;
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -115,6 +115,10 @@ library TFHE {
         return euint8.wrap(Impl.verify(ciphertext, Common.euint8_t));
     }
 
+    function asEuint8(uint256 value) internal view returns (euint8) {
+        return euint8.wrap(Impl.trivialEncrypt(value, Common.euint8_t));
+    }
+
     function reencrypt(
         euint8 ciphertext,
         bytes32 publicKey
@@ -136,6 +140,10 @@ library TFHE {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
+    function asEuint16(uint256 value) internal view returns (euint16) {
+        return euint16.wrap(Impl.trivialEncrypt(value, Common.euint16_t));
+    }
+
     function reencrypt(
         euint16 ciphertext,
         bytes32 publicKey
@@ -155,6 +163,10 @@ library TFHE {
         bytes memory ciphertext
     ) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
+    }
+
+    function asEuint32(uint256 value) internal view returns (euint32) {
+        return euint32.wrap(Impl.trivialEncrypt(value, Common.euint32_t));
     }
 
     function reencrypt(


### PR DESCRIPTION
Add an overload for `asEuintX` that takes as input a `uint256` value and returns a handle to the trivial encryption of said value.
Contributes to zama-ai/go-ethereum#116 and #46.
Meant to be used with zama-ai/go-ethereum/pull/117.