### PR TITLE
feat: add casting

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -37,6 +37,7 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
 }
 """
@@ -299,11 +300,41 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the cast precompile.
+        // Call the verify precompile.
         uint256 precompile = Precompiles.Verify;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
             if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
+    function cast(
+        uint256 ciphertext,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the cast precompile.
+        uint256 precompile = Precompiles.Cast;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -401,6 +432,17 @@ for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
         if i == j: # TODO: remove this line when casting is implemented
             f.write(to_print.format(i=i, j=j, k=i if i>j else j))
+
+to_print="""
+    function asEuint{i}(euint{j} ciphertext) internal view returns (euint{i}) {{
+        return euint{i}.wrap(Impl.cast(euint{j}.unwrap(ciphertext), Common.euint{i}_t));
+    }}
+"""
+
+for i in (2**p for p in range(3, 6)):
+    for j in (2**p for p in range(3, 6)):
+        if i != j:
+            f.write(to_print.format(i=i, j=j))
 
 to_print="""
     function asEuint{i}(bytes memory ciphertext) internal view returns (euint{i}) {{

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -30,16 +30,7 @@ library Impl {
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -64,16 +55,7 @@ library Impl {
         // Call the sub precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -98,16 +80,7 @@ library Impl {
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -117,10 +90,7 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -132,16 +102,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -151,10 +112,7 @@ library Impl {
 
     // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lt(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -166,16 +124,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -186,11 +135,7 @@ library Impl {
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.
-    function cmux(
-        uint256 control,
-        uint256 ifTrue,
-        uint256 ifFalse
-    ) internal view returns (uint256 result) {
+    function cmux(uint256 control, uint256 ifTrue, uint256 ifFalse) internal view returns (uint256 result) {
         // result = (ifTrue - ifFalse) * control + ifFalse
 
         bytes32[2] memory input;
@@ -203,16 +148,7 @@ library Impl {
         uint256 precompile = Precompiles.Subtract;
         bytes32[1] memory subOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    subOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, subOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -223,16 +159,7 @@ library Impl {
         precompile = Precompiles.Multiply;
         bytes32[1] memory mulOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    mulOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, mulOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -243,23 +170,14 @@ library Impl {
         precompile = Precompiles.Add;
         bytes32[1] memory addOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    addOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, addOutput, outputLen)) {
                 revert(0, 0)
             }
         }
 
         result = uint256(addOutput[0]);
     }
-
+    
     // Optimistically requires that the `ciphertext` is true.
     //
     // This function does not evaluate the given `ciphertext` at the time of the call.
@@ -286,10 +204,7 @@ library Impl {
         }
     }
 
-    function reencrypt(
-        uint256 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
         input[1] = publicKey;
@@ -300,16 +215,7 @@ library Impl {
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    reencrypted,
-                    reencryptedSize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, reencryptedSize)) {
                 revert(0, 0)
             }
         }
@@ -321,7 +227,16 @@ library Impl {
         // Call the fhePubKey precompile.
         uint256 precompile = Precompiles.FhePubKey;
         assembly {
-            if iszero(staticcall(gas(), precompile, 0, 0, key, fhePubKeySize)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    0,
+                    0,
+                    key,
+                    fhePubKeySize
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -337,8 +252,29 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the cast precompile.
+        // Call the verify precompile.
         uint256 precompile = Precompiles.Verify;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
+    function cast(
+        uint256 ciphertext,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the cast precompile.
+        uint256 precompile = Precompiles.Cast;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
             if iszero(

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -30,7 +30,16 @@ library Impl {
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -55,7 +64,16 @@ library Impl {
         // Call the sub precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -80,7 +98,16 @@ library Impl {
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -90,7 +117,10 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+    function lte(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -102,7 +132,16 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -112,7 +151,10 @@ library Impl {
 
     // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+    function lt(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -124,7 +166,16 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -135,7 +186,11 @@ library Impl {
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.
-    function cmux(uint256 control, uint256 ifTrue, uint256 ifFalse) internal view returns (uint256 result) {
+    function cmux(
+        uint256 control,
+        uint256 ifTrue,
+        uint256 ifFalse
+    ) internal view returns (uint256 result) {
         // result = (ifTrue - ifFalse) * control + ifFalse
 
         bytes32[2] memory input;
@@ -148,7 +203,16 @@ library Impl {
         uint256 precompile = Precompiles.Subtract;
         bytes32[1] memory subOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, subOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    subOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -159,7 +223,16 @@ library Impl {
         precompile = Precompiles.Multiply;
         bytes32[1] memory mulOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, mulOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    mulOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -170,14 +243,23 @@ library Impl {
         precompile = Precompiles.Add;
         bytes32[1] memory addOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, addOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    addOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
 
         result = uint256(addOutput[0]);
     }
-    
+
     // Optimistically requires that the `ciphertext` is true.
     //
     // This function does not evaluate the given `ciphertext` at the time of the call.
@@ -204,7 +286,10 @@ library Impl {
         }
     }
 
-    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        uint256 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
         input[1] = publicKey;
@@ -215,7 +300,16 @@ library Impl {
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, reencryptedSize)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    reencrypted,
+                    reencryptedSize
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -227,16 +321,7 @@ library Impl {
         // Call the fhePubKey precompile.
         uint256 precompile = Precompiles.FhePubKey;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    0,
-                    0,
-                    key,
-                    fhePubKeySize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, 0, 0, key, fhePubKeySize)) {
                 revert(0, 0)
             }
         }
@@ -256,7 +341,16 @@ library Impl {
         uint256 precompile = Precompiles.Verify;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
-            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -13,5 +13,6 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -186,40 +186,87 @@ library TFHE {
         return lt(a, asEuint32(b));
     }
 
-    function cmux(euint8 control, euint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.cmux(euint8.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint8 a,
+        euint8 b
+    ) internal view returns (euint8) {
+        return
+            euint8.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint8.unwrap(a),
+                    euint8.unwrap(b)
+                )
+            );
     }
 
-    function cmux(euint8 control, euint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.cmux(euint8.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint16 a,
+        euint16 b
+    ) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint16.unwrap(a),
+                    euint16.unwrap(b)
+                )
+            );
     }
 
-    function cmux(euint8 control, euint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.cmux(euint8.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint32 a,
+        euint32 b
+    ) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint32.unwrap(a),
+                    euint32.unwrap(b)
+                )
+            );
     }
 
     function asEuint8(euint16 ciphertext) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
+        return
+            euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
     }
 
     function asEuint8(euint32 ciphertext) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
+        return
+            euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
     }
 
     function asEuint16(euint8 ciphertext) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t));
+        return
+            euint16.wrap(
+                Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t)
+            );
     }
 
     function asEuint16(euint32 ciphertext) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t));
+        return
+            euint16.wrap(
+                Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t)
+            );
     }
 
     function asEuint32(euint8 ciphertext) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t));
+        return
+            euint32.wrap(
+                Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t)
+            );
     }
 
     function asEuint32(euint16 ciphertext) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t));
+        return
+            euint32.wrap(
+                Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t)
+            );
     }
 
     function asEuint8(bytes memory ciphertext) internal view returns (euint8) {
@@ -230,7 +277,10 @@ library TFHE {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.euint8_t));
     }
 
-    function reencrypt(euint8 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint8 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
 
@@ -242,7 +292,9 @@ library TFHE {
         Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
     }
 
-    function asEuint16(bytes memory ciphertext) internal view returns (euint16) {
+    function asEuint16(
+        bytes memory ciphertext
+    ) internal view returns (euint16) {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
@@ -250,7 +302,10 @@ library TFHE {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.euint16_t));
     }
 
-    function reencrypt(euint16 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint16 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
 
@@ -262,7 +317,9 @@ library TFHE {
         Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
-    function asEuint32(bytes memory ciphertext) internal view returns (euint32) {
+    function asEuint32(
+        bytes memory ciphertext
+    ) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
     }
 
@@ -270,7 +327,10 @@ library TFHE {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.euint32_t));
     }
 
-    function reencrypt(euint32 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint32 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }
 

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -186,49 +186,40 @@ library TFHE {
         return lt(a, asEuint32(b));
     }
 
-    function cmux(
-        euint8 control,
-        euint8 a,
-        euint8 b
-    ) internal view returns (euint8) {
-        return
-            euint8.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint8.unwrap(a),
-                    euint8.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.cmux(euint8.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint16 a,
-        euint16 b
-    ) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint16.unwrap(a),
-                    euint16.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.cmux(euint8.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint32 a,
-        euint32 b
-    ) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint32.unwrap(a),
-                    euint32.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.cmux(euint8.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function asEuint8(euint16 ciphertext) internal view returns (euint8) {
+        return euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
+    }
+
+    function asEuint8(euint32 ciphertext) internal view returns (euint8) {
+        return euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
+    }
+
+    function asEuint16(euint8 ciphertext) internal view returns (euint16) {
+        return euint16.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t));
+    }
+
+    function asEuint16(euint32 ciphertext) internal view returns (euint16) {
+        return euint16.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t));
+    }
+
+    function asEuint32(euint8 ciphertext) internal view returns (euint32) {
+        return euint32.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t));
+    }
+
+    function asEuint32(euint16 ciphertext) internal view returns (euint32) {
+        return euint32.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t));
     }
 
     function asEuint8(bytes memory ciphertext) internal view returns (euint8) {
@@ -239,10 +230,7 @@ library TFHE {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.euint8_t));
     }
 
-    function reencrypt(
-        euint8 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint8 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
 
@@ -254,9 +242,7 @@ library TFHE {
         Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
     }
 
-    function asEuint16(
-        bytes memory ciphertext
-    ) internal view returns (euint16) {
+    function asEuint16(bytes memory ciphertext) internal view returns (euint16) {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
@@ -264,10 +250,7 @@ library TFHE {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.euint16_t));
     }
 
-    function reencrypt(
-        euint16 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint16 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
 
@@ -279,9 +262,7 @@ library TFHE {
         Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
-    function asEuint32(
-        bytes memory ciphertext
-    ) internal view returns (euint32) {
+    function asEuint32(bytes memory ciphertext) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
     }
 
@@ -289,10 +270,7 @@ library TFHE {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.euint32_t));
     }
 
-    function reencrypt(
-        euint32 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint32 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }
 


### PR DESCRIPTION
Add support for casting. Meant to be used with zama-ai/go-ethereum#118. Closes zama-ai/go-ethereum#119. 