### PR TITLE
feat(fhe): add missing FHE operators

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -532,44 +532,88 @@ import "./Impl.sol";
 
 library TFHE {""")
 
-to_print =  """
+to_print_no_cast =  """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b)));
     }}
+"""
 
-    function {f}(uint256 a, euint{i} b) internal view returns (euint{k}) {{
-        return {f}(asEuint{i}(a), b);
+to_print_cast_a =  """
+    function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b)));
     }}
 
-    function {f}(euint{i} a, uint256 b) internal view returns (euint{k}) {{
-        return {f}(a, asEuint{i}(b));
+    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(asEuint{j}(b))));
+    }}
+
+    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b)));
+    }}
+"""
+
+to_print_cast_b =  """
+    function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b))));
+    }}
+
+    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b))));
+    }}
+
+    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(asEuint{i}(a)), euint{i}.unwrap(asEuint{i}(b))));
     }}
 """
 
 for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
-        if i == j: # TODO: remove this line when casting is implemented
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="add"))
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="sub"))
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="mul"))
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="and"))
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="or"))
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="xor"))
-            f.write(to_print.format(i=i, j=j, k=i, f="eq"))
-            f.write(to_print.format(i=i, j=j, k=i, f="ge"))
-            f.write(to_print.format(i=i, j=j, k=i, f="gt"))
-            f.write(to_print.format(i=i, j=j, k=i, f="lte"))
-            f.write(to_print.format(i=i, j=j, k=i, f="lt"))
+        if i == j:
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="add")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="sub")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="mul")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="and")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="or")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="xor")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="eq")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="ge")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="gt")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="lte")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="lt")))
+        elif i < j:
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="add")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="sub")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="mul")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="and")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="or")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="xor")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="eq")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="ge")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="gt")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="lte")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="lt")))
+        else:
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="add")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="sub")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="mul")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="and")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="or")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="xor")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="eq")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="ge")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="gt")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="lte")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="lt")))
 
 to_print =  """
-    function cmux(euint8 control, euint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.cmux(euint8.unwrap(control), euint{i}.unwrap(a), euint{j}.unwrap(b)));
+    function cmux(euint{i} control, euint{i} a, euint{i} b) internal view returns (euint{i}) {{
+        return euint{i}.wrap(Impl.cmux(euint{i}.unwrap(control), euint{i}.unwrap(a), euint{i}.unwrap(b)));
     }}
 """
 for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
-        if i == j: # TODO: remove this line when casting is implemented
-            f.write(to_print.format(i=i, j=j, k=i if i>j else j))
+        if i == j: # TODO: Decide whether we want to have mixed-inputs for CMUX
+            f.write(to_print.format(i=i))
 
 to_print="""
     function asEuint{i}(euint{j} ciphertext) internal view returns (euint{i}) {{
@@ -598,7 +642,15 @@ to_print="""
     function requireCt(euint{i} ciphertext) internal view {{
         Impl.requireCt(euint{i}.unwrap(ciphertext));
     }}
+"""
 
+to_print_cast_or="""
+    function optimisticRequireCt(euint{i} ciphertext) internal view {{
+        Impl.optimisticRequireCt(euint32.unwrap(asEuint32(ciphertext)));
+    }}
+"""
+
+to_print_no_cast_or="""
     function optimisticRequireCt(euint{i} ciphertext) internal view {{
         Impl.optimisticRequireCt(euint{i}.unwrap(ciphertext));
     }}
@@ -606,6 +658,11 @@ to_print="""
 
 for i in (2**p for p in range(3, 6)):
     f.write(to_print.format(i=i))
+    if i != 32:
+        f.write(to_print_cast_or.format(i=i))
+    else:
+        f.write(to_print_no_cast_or.format(i=i))
+
 
 f.write("\n")
 f.write("""\

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -39,6 +39,12 @@ library Precompiles {
     uint256 public constant OptimisticRequire = 75;
     uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
+    uint256 public constant BitwiseAnd = 78;
+    uint256 public constant BitwiseOr = 79;
+    uint256 public constant BitwiseXor = 80;
+    uint256 public constant Equal = 81;
+    uint256 public constant GreaterThanOrEqual = 82;
+    uint256 public constant GreaterThan = 83;
 }
 """
 )
@@ -127,6 +133,132 @@ library Impl {
 
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function and(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the AND precompile.
+        uint256 precompile = Precompiles.BitwiseAnd;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function or(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the OR precompile.
+        uint256 precompile = Precompiles.BitwiseOr;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function xor(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the XOR precompile.
+        uint256 precompile = Precompiles.BitwiseXor;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs == rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function eq(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the eq precompile.
+        uint256 precompile = Precompiles.Equal;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs >= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function ge(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the ge precompile.
+        uint256 precompile = Precompiles.GreaterThanOrEqual;
+        assembly {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs > rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function gt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the gt precompile.
+        uint256 precompile = Precompiles.GreaterThan;
         assembly {
             if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
@@ -420,6 +552,12 @@ for i in (2**p for p in range(3, 6)):
             f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="add"))
             f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="sub"))
             f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="mul"))
+            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="and"))
+            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="or"))
+            f.write(to_print.format(i=i, j=j, k=i if i>j else j, f="xor"))
+            f.write(to_print.format(i=i, j=j, k=i, f="eq"))
+            f.write(to_print.format(i=i, j=j, k=i, f="ge"))
+            f.write(to_print.format(i=i, j=j, k=i, f="gt"))
             f.write(to_print.format(i=i, j=j, k=i, f="lte"))
             f.write(to_print.format(i=i, j=j, k=i, f="lt"))
 

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -270,7 +270,7 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+    function le(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -279,7 +279,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the lte precompile.
+        // Call the le precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
             if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
@@ -301,7 +301,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the lte precompile.
+        // Call the lt precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
             if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
@@ -578,7 +578,7 @@ for i in (2**p for p in range(3, 6)):
             f.write((to_print_no_cast.format(i=i, j=j, k=i, f="eq")))
             f.write((to_print_no_cast.format(i=i, j=j, k=i, f="ge")))
             f.write((to_print_no_cast.format(i=i, j=j, k=i, f="gt")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="lte")))
+            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="le")))
             f.write((to_print_no_cast.format(i=i, j=j, k=i, f="lt")))
         elif i < j:
             f.write((to_print_cast_a.format(i=i, j=j, k=j, f="add")))
@@ -590,7 +590,7 @@ for i in (2**p for p in range(3, 6)):
             f.write((to_print_cast_a.format(i=i, j=j, k=j, f="eq")))
             f.write((to_print_cast_a.format(i=i, j=j, k=j, f="ge")))
             f.write((to_print_cast_a.format(i=i, j=j, k=j, f="gt")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="lte")))
+            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="le")))
             f.write((to_print_cast_a.format(i=i, j=j, k=j, f="lt")))
         else:
             f.write((to_print_cast_b.format(i=i, j=j, k=i, f="add")))
@@ -602,7 +602,7 @@ for i in (2**p for p in range(3, 6)):
             f.write((to_print_cast_b.format(i=i, j=j, k=i, f="eq")))
             f.write((to_print_cast_b.format(i=i, j=j, k=i, f="ge")))
             f.write((to_print_cast_b.format(i=i, j=j, k=i, f="gt")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="lte")))
+            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="le")))
             f.write((to_print_cast_b.format(i=i, j=j, k=i, f="lt")))
 
 to_print =  """

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -37,6 +37,7 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
 }
 """
@@ -299,11 +300,41 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the cast precompile.
+        // Call the verify precompile.
         uint256 precompile = Precompiles.Verify;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
             if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
+    function cast(
+        uint256 ciphertext,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the cast precompile.
+        uint256 precompile = Precompiles.Cast;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -401,6 +432,17 @@ for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
         if i == j: # TODO: remove this line when casting is implemented
             f.write(to_print.format(i=i, j=j, k=i if i>j else j))
+
+to_print="""
+    function asEuint{i}(euint{j} ciphertext) internal view returns (euint{i}) {{
+        return euint{i}.wrap(Impl.cast(euint{j}.unwrap(ciphertext), Common.euint{i}_t));
+    }}
+"""
+
+for i in (2**p for p in range(3, 6)):
+    for j in (2**p for p in range(3, 6)):
+        if i != j:
+            f.write(to_print.format(i=i, j=j))
 
 to_print="""
     function asEuint{i}(bytes memory ciphertext) internal view returns (euint{i}) {{

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -93,14 +93,13 @@ contract BlindAuction is EIP712WithModifier {
         onlySignedPublicKey(publicKey, signature)
         returns (bytes memory)
     {
-        return
-            TFHE.reencrypt(TFHE.lte(highestBid, bids[msg.sender]), publicKey);
+        return TFHE.reencrypt(TFHE.le(highestBid, bids[msg.sender]), publicKey);
     }
 
     // Claim the object. Succeeds only if the caller has the highest bid.
     function claim() public onlyAfterEnd {
         require(!objectClaimed);
-        TFHE.requireCt(TFHE.lte(highestBid, bids[msg.sender]));
+        TFHE.requireCt(TFHE.le(highestBid, bids[msg.sender]));
 
         objectClaimed = true;
         bids[msg.sender] = euint8.wrap(0);

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -128,14 +128,14 @@ contract EncryptedERC20 is EIP712WithModifier {
         euint32 amount
     ) internal {
         euint32 currentAllowance = _allowance(owner, spender);
-        TFHE.requireCt(TFHE.lte(amount, currentAllowance));
+        TFHE.requireCt(TFHE.le(amount, currentAllowance));
         _approve(owner, spender, TFHE.sub(currentAllowance, amount));
     }
 
     // Transfers an encrypted amount.
     function _transfer(address from, address to, euint32 amount) internal {
         // Make sure the sender has enough tokens.
-        TFHE.requireCt(TFHE.lte(amount, balances[from]));
+        TFHE.requireCt(TFHE.le(amount, balances[from]));
 
         // Add to the balance of `to` and subract from the balance of `from`.
         balances[to] = TFHE.add(balances[to], amount);

--- a/examples/OptimisticRequire.sol
+++ b/examples/OptimisticRequire.sol
@@ -36,10 +36,10 @@ contract OptimisticRequire {
     // Charge full gas as both requires are true.
     function optimisticRequireCtTrue() public {
         // True.
-        TFHE.optimisticRequireCt(TFHE.lte(ct1, ct2));
+        TFHE.optimisticRequireCt(TFHE.le(ct1, ct2));
 
         // True.
-        TFHE.optimisticRequireCt(TFHE.lte(ct1, ct2));
+        TFHE.optimisticRequireCt(TFHE.le(ct1, ct2));
 
         // Mutate state to pay for gas.
         doWorkToPayGas();
@@ -48,7 +48,7 @@ contract OptimisticRequire {
     // Charge full gas as we are using optimistic requires.
     function optimisticRequireCtFalse() public {
         // True.
-        TFHE.optimisticRequireCt(TFHE.lte(ct1, ct2));
+        TFHE.optimisticRequireCt(TFHE.le(ct1, ct2));
 
         // False.
         TFHE.optimisticRequireCt(TFHE.lt(ct1, ct2));
@@ -60,7 +60,7 @@ contract OptimisticRequire {
     // Charge less than full gas, because the non-optimistic ciphertext require aborts early.
     function requireCtFalse() public {
         // True.
-        TFHE.requireCt(TFHE.lte(ct1, ct2));
+        TFHE.requireCt(TFHE.le(ct1, ct2));
 
         // False.
         TFHE.requireCt(TFHE.lt(ct1, ct2));

--- a/examples/SmallEncryptedERC20.sol
+++ b/examples/SmallEncryptedERC20.sol
@@ -124,14 +124,14 @@ contract SmallEncryptedERC20 is EIP712WithModifier {
         euint8 amount
     ) internal {
         euint8 currentAllowance = _allowance(owner, spender);
-        TFHE.requireCt(TFHE.lte(amount, currentAllowance));
+        TFHE.requireCt(TFHE.le(amount, currentAllowance));
         _approve(owner, spender, TFHE.sub(currentAllowance, amount));
     }
 
     // Transfers an encrypted amount.
     function _transfer(address from, address to, euint8 amount) internal {
         // Make sure the sender has enough tokens.
-        TFHE.requireCt(TFHE.lte(amount, balances[from]));
+        TFHE.requireCt(TFHE.le(amount, balances[from]));
 
         // Add to the balance of `to` and subract from the balance of `from`.
         balances[to] = TFHE.add(balances[to], amount);

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -30,7 +30,16 @@ library Impl {
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -55,7 +64,16 @@ library Impl {
         // Call the sub precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -80,7 +98,205 @@ library Impl {
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function and(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the AND precompile.
+        uint256 precompile = Precompiles.BitwiseAnd;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function or(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the OR precompile.
+        uint256 precompile = Precompiles.BitwiseOr;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    function xor(uint256 a, uint256 b) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(a);
+        input[1] = bytes32(b);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the XOR precompile.
+        uint256 precompile = Precompiles.BitwiseXor;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs == rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function eq(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the eq precompile.
+        uint256 precompile = Precompiles.Equal;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs >= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function ge(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the ge precompile.
+        uint256 precompile = Precompiles.GreaterThanOrEqual;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
+    // Evaluate `lhs > rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
+    // If successful, the resulting ciphertext is automatically verified.
+    function gt(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
+        bytes32[2] memory input;
+        input[0] = bytes32(lhs);
+        input[1] = bytes32(rhs);
+        uint256 inputLen = 64;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the gt precompile.
+        uint256 precompile = Precompiles.GreaterThan;
+        assembly {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -90,7 +306,10 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+    function lte(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -102,7 +321,16 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -112,7 +340,10 @@ library Impl {
 
     // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
+    function lt(
+        uint256 lhs,
+        uint256 rhs
+    ) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -124,7 +355,16 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -135,7 +375,11 @@ library Impl {
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.
-    function cmux(uint256 control, uint256 ifTrue, uint256 ifFalse) internal view returns (uint256 result) {
+    function cmux(
+        uint256 control,
+        uint256 ifTrue,
+        uint256 ifFalse
+    ) internal view returns (uint256 result) {
         // result = (ifTrue - ifFalse) * control + ifFalse
 
         bytes32[2] memory input;
@@ -148,7 +392,16 @@ library Impl {
         uint256 precompile = Precompiles.Subtract;
         bytes32[1] memory subOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, subOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    subOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -159,7 +412,16 @@ library Impl {
         precompile = Precompiles.Multiply;
         bytes32[1] memory mulOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, mulOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    mulOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -170,14 +432,23 @@ library Impl {
         precompile = Precompiles.Add;
         bytes32[1] memory addOutput;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, addOutput, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    addOutput,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }
 
         result = uint256(addOutput[0]);
     }
-    
+
     // Optimistically requires that the `ciphertext` is true.
     //
     // This function does not evaluate the given `ciphertext` at the time of the call.
@@ -204,7 +475,10 @@ library Impl {
         }
     }
 
-    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        uint256 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
         input[1] = publicKey;
@@ -215,7 +489,16 @@ library Impl {
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, reencryptedSize)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    input,
+                    inputLen,
+                    reencrypted,
+                    reencryptedSize
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -227,16 +510,7 @@ library Impl {
         // Call the fhePubKey precompile.
         uint256 precompile = Precompiles.FhePubKey;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    0,
-                    0,
-                    key,
-                    fhePubKeySize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, 0, 0, key, fhePubKeySize)) {
                 revert(0, 0)
             }
         }
@@ -256,7 +530,16 @@ library Impl {
         uint256 precompile = Precompiles.Verify;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
-            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    add(input, 32),
+                    inputLen,
+                    output,
+                    outputLen
+                )
+            ) {
                 revert(0, 0)
             }
         }

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -306,7 +306,7 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(
+    function le(
         uint256 lhs,
         uint256 rhs
     ) internal view returns (uint256 result) {
@@ -318,7 +318,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the lte precompile.
+        // Call the le precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
             if iszero(
@@ -352,7 +352,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the lte precompile.
+        // Call the lt precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
             if iszero(

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -30,16 +30,7 @@ library Impl {
         // Call the add precompile.
         uint256 precompile = Precompiles.Add;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -64,16 +55,7 @@ library Impl {
         // Call the sub precompile.
         uint256 precompile = Precompiles.Subtract;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -98,16 +80,7 @@ library Impl {
         // Call the mul precompile.
         uint256 precompile = Precompiles.Multiply;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -117,10 +90,7 @@ library Impl {
 
     // Evaluate `lhs <= rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lte(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lte(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -132,16 +102,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThanOrEqual;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -151,10 +112,7 @@ library Impl {
 
     // Evaluate `lhs < rhs` on the given ciphertexts and, if successful, return the resulting ciphertext.
     // If successful, the resulting ciphertext is automatically verified.
-    function lt(
-        uint256 lhs,
-        uint256 rhs
-    ) internal view returns (uint256 result) {
+    function lt(uint256 lhs, uint256 rhs) internal view returns (uint256 result) {
         bytes32[2] memory input;
         input[0] = bytes32(lhs);
         input[1] = bytes32(rhs);
@@ -166,16 +124,7 @@ library Impl {
         // Call the lte precompile.
         uint256 precompile = Precompiles.LessThan;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    output,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -186,11 +135,7 @@ library Impl {
     // If `control`'s value is 1, the resulting value is the same value as `ifTrue`.
     // If `control`'s value is 0, the resulting value is the same value as `ifFalse`.
     // If successful, the resulting ciphertext is automatically verified.
-    function cmux(
-        uint256 control,
-        uint256 ifTrue,
-        uint256 ifFalse
-    ) internal view returns (uint256 result) {
+    function cmux(uint256 control, uint256 ifTrue, uint256 ifFalse) internal view returns (uint256 result) {
         // result = (ifTrue - ifFalse) * control + ifFalse
 
         bytes32[2] memory input;
@@ -203,16 +148,7 @@ library Impl {
         uint256 precompile = Precompiles.Subtract;
         bytes32[1] memory subOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    subOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, subOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -223,16 +159,7 @@ library Impl {
         precompile = Precompiles.Multiply;
         bytes32[1] memory mulOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    mulOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, mulOutput, outputLen)) {
                 revert(0, 0)
             }
         }
@@ -243,23 +170,14 @@ library Impl {
         precompile = Precompiles.Add;
         bytes32[1] memory addOutput;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    addOutput,
-                    outputLen
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, addOutput, outputLen)) {
                 revert(0, 0)
             }
         }
 
         result = uint256(addOutput[0]);
     }
-
+    
     // Optimistically requires that the `ciphertext` is true.
     //
     // This function does not evaluate the given `ciphertext` at the time of the call.
@@ -286,10 +204,7 @@ library Impl {
         }
     }
 
-    function reencrypt(
-        uint256 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         bytes32[2] memory input;
         input[0] = bytes32(ciphertext);
         input[1] = publicKey;
@@ -300,16 +215,7 @@ library Impl {
         // Call the reencrypt precompile.
         uint256 precompile = Precompiles.Reencrypt;
         assembly {
-            if iszero(
-                staticcall(
-                    gas(),
-                    precompile,
-                    input,
-                    inputLen,
-                    reencrypted,
-                    reencryptedSize
-                )
-            ) {
+            if iszero(staticcall(gas(), precompile, input, inputLen, reencrypted, reencryptedSize)) {
                 revert(0, 0)
             }
         }
@@ -321,7 +227,16 @@ library Impl {
         // Call the fhePubKey precompile.
         uint256 precompile = Precompiles.FhePubKey;
         assembly {
-            if iszero(staticcall(gas(), precompile, 0, 0, key, fhePubKeySize)) {
+            if iszero(
+                staticcall(
+                    gas(),
+                    precompile,
+                    0,
+                    0,
+                    key,
+                    fhePubKeySize
+                )
+            ) {
                 revert(0, 0)
             }
         }
@@ -337,8 +252,29 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the cast precompile.
+        // Call the verify precompile.
         uint256 precompile = Precompiles.Verify;
+        assembly {
+            // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+        result = uint256(output[0]);
+    }
+
+    function cast(
+        uint256 ciphertext,
+        uint8 toType
+    ) internal view returns (uint256 result) {
+        bytes memory input = bytes.concat(bytes32(ciphertext), bytes1(toType));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the cast precompile.
+        uint256 precompile = Precompiles.Cast;
         assembly {
             // jump over the 32-bit `size` field of the `bytes` data structure of the `input` to read actual bytes
             if iszero(

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -15,4 +15,10 @@ library Precompiles {
     uint256 public constant OptimisticRequire = 75;
     uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
+    uint256 public constant BitwiseAnd = 78;
+    uint256 public constant BitwiseOr = 79;
+    uint256 public constant BitwiseXor = 80;
+    uint256 public constant Equal = 81;
+    uint256 public constant GreaterThanOrEqual = 82;
+    uint256 public constant GreaterThan = 83;
 }

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -13,5 +13,6 @@ library Precompiles {
     uint256 public constant Multiply = 72;
     uint256 public constant LessThan = 73;
     uint256 public constant OptimisticRequire = 75;
+    uint256 public constant Cast = 76;
     uint256 public constant TrivialEncrypt = 77;
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -10,396 +10,1716 @@ library TFHE {
         return euint8.wrap(Impl.add(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function add(uint256 a, euint8 b) internal view returns (euint8) {
-        return add(asEuint8(a), b);
-    }
-
-    function add(euint8 a, uint256 b) internal view returns (euint8) {
-        return add(a, asEuint8(b));
-    }
-
     function sub(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.sub(euint8.unwrap(a), euint8.unwrap(b)));
-    }
-
-    function sub(uint256 a, euint8 b) internal view returns (euint8) {
-        return sub(asEuint8(a), b);
-    }
-
-    function sub(euint8 a, uint256 b) internal view returns (euint8) {
-        return sub(a, asEuint8(b));
     }
 
     function mul(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.mul(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function mul(uint256 a, euint8 b) internal view returns (euint8) {
-        return mul(asEuint8(a), b);
-    }
-
-    function mul(euint8 a, uint256 b) internal view returns (euint8) {
-        return mul(a, asEuint8(b));
-    }
-
     function and(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(b)));
-    }
-
-    function and(uint256 a, euint8 b) internal view returns (euint8) {
-        return and(asEuint8(a), b);
-    }
-
-    function and(euint8 a, uint256 b) internal view returns (euint8) {
-        return and(a, asEuint8(b));
     }
 
     function or(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function or(uint256 a, euint8 b) internal view returns (euint8) {
-        return or(asEuint8(a), b);
-    }
-
-    function or(euint8 a, uint256 b) internal view returns (euint8) {
-        return or(a, asEuint8(b));
-    }
-
     function xor(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
-    }
-
-    function xor(uint256 a, euint8 b) internal view returns (euint8) {
-        return xor(asEuint8(a), b);
-    }
-
-    function xor(euint8 a, uint256 b) internal view returns (euint8) {
-        return xor(a, asEuint8(b));
     }
 
     function eq(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function eq(uint256 a, euint8 b) internal view returns (euint8) {
-        return eq(asEuint8(a), b);
-    }
-
-    function eq(euint8 a, uint256 b) internal view returns (euint8) {
-        return eq(a, asEuint8(b));
-    }
-
     function ge(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b)));
-    }
-
-    function ge(uint256 a, euint8 b) internal view returns (euint8) {
-        return ge(asEuint8(a), b);
-    }
-
-    function ge(euint8 a, uint256 b) internal view returns (euint8) {
-        return ge(a, asEuint8(b));
     }
 
     function gt(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function gt(uint256 a, euint8 b) internal view returns (euint8) {
-        return gt(asEuint8(a), b);
-    }
-
-    function gt(euint8 a, uint256 b) internal view returns (euint8) {
-        return gt(a, asEuint8(b));
-    }
-
     function lte(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.lte(euint8.unwrap(a), euint8.unwrap(b)));
-    }
-
-    function lte(uint256 a, euint8 b) internal view returns (euint8) {
-        return lte(asEuint8(a), b);
-    }
-
-    function lte(euint8 a, uint256 b) internal view returns (euint8) {
-        return lte(a, asEuint8(b));
     }
 
     function lt(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function lt(uint256 a, euint8 b) internal view returns (euint8) {
-        return lt(asEuint8(a), b);
+    function add(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
     }
 
-    function lt(euint8 a, uint256 b) internal view returns (euint8) {
-        return lt(a, asEuint8(b));
+    function add(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function add(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function sub(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function sub(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function sub(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function mul(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function mul(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function mul(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function and(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function and(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function and(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function or(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function or(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function or(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function xor(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function xor(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function xor(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function eq(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function eq(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function eq(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function ge(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function ge(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function ge(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function gt(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function gt(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function gt(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function lte(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function lte(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function lte(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function lt(euint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function lt(euint8 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function lt(uint8 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
+    function add(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function add(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function add(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function sub(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function sub(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function sub(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function mul(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function mul(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function mul(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function and(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function and(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function and(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function or(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function or(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function or(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function xor(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function xor(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function xor(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function eq(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function eq(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function eq(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function ge(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function ge(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function ge(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function gt(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function gt(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function gt(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lte(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lte(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lte(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lt(euint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lt(euint8 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lt(uint8 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function add(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function add(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function add(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.add(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function sub(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function sub(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function sub(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.sub(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function mul(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function mul(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function mul(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.mul(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function and(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function and(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function and(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function or(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function or(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function or(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function xor(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function xor(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function xor(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function eq(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function eq(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function eq(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.eq(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function ge(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function ge(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function ge(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.ge(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function gt(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function gt(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function gt(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.gt(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function lte(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function lte(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function lte(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lte(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
+    }
+
+    function lt(euint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function lt(euint16 a, uint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function lt(uint16 a, euint8 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.lt(
+                    euint16.unwrap(asEuint16(a)),
+                    euint16.unwrap(asEuint16(b))
+                )
+            );
     }
 
     function add(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.add(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function add(uint256 a, euint16 b) internal view returns (euint16) {
-        return add(asEuint16(a), b);
-    }
-
-    function add(euint16 a, uint256 b) internal view returns (euint16) {
-        return add(a, asEuint16(b));
-    }
-
     function sub(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.sub(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    function sub(uint256 a, euint16 b) internal view returns (euint16) {
-        return sub(asEuint16(a), b);
-    }
-
-    function sub(euint16 a, uint256 b) internal view returns (euint16) {
-        return sub(a, asEuint16(b));
     }
 
     function mul(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.mul(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function mul(uint256 a, euint16 b) internal view returns (euint16) {
-        return mul(asEuint16(a), b);
-    }
-
-    function mul(euint16 a, uint256 b) internal view returns (euint16) {
-        return mul(a, asEuint16(b));
-    }
-
     function and(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.and(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    function and(uint256 a, euint16 b) internal view returns (euint16) {
-        return and(asEuint16(a), b);
-    }
-
-    function and(euint16 a, uint256 b) internal view returns (euint16) {
-        return and(a, asEuint16(b));
     }
 
     function or(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.or(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function or(uint256 a, euint16 b) internal view returns (euint16) {
-        return or(asEuint16(a), b);
-    }
-
-    function or(euint16 a, uint256 b) internal view returns (euint16) {
-        return or(a, asEuint16(b));
-    }
-
     function xor(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    function xor(uint256 a, euint16 b) internal view returns (euint16) {
-        return xor(asEuint16(a), b);
-    }
-
-    function xor(euint16 a, uint256 b) internal view returns (euint16) {
-        return xor(a, asEuint16(b));
     }
 
     function eq(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.eq(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function eq(uint256 a, euint16 b) internal view returns (euint16) {
-        return eq(asEuint16(a), b);
-    }
-
-    function eq(euint16 a, uint256 b) internal view returns (euint16) {
-        return eq(a, asEuint16(b));
-    }
-
     function ge(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.ge(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    function ge(uint256 a, euint16 b) internal view returns (euint16) {
-        return ge(asEuint16(a), b);
-    }
-
-    function ge(euint16 a, uint256 b) internal view returns (euint16) {
-        return ge(a, asEuint16(b));
     }
 
     function gt(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.gt(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function gt(uint256 a, euint16 b) internal view returns (euint16) {
-        return gt(asEuint16(a), b);
-    }
-
-    function gt(euint16 a, uint256 b) internal view returns (euint16) {
-        return gt(a, asEuint16(b));
-    }
-
     function lte(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.lte(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    function lte(uint256 a, euint16 b) internal view returns (euint16) {
-        return lte(asEuint16(a), b);
-    }
-
-    function lte(euint16 a, uint256 b) internal view returns (euint16) {
-        return lte(a, asEuint16(b));
     }
 
     function lt(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.lt(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function lt(uint256 a, euint16 b) internal view returns (euint16) {
-        return lt(asEuint16(a), b);
+    function add(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
     }
 
-    function lt(euint16 a, uint256 b) internal view returns (euint16) {
-        return lt(a, asEuint16(b));
+    function add(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function add(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function sub(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function sub(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function sub(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function mul(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function mul(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function mul(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function and(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function and(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function and(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function or(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function or(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function or(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function xor(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function xor(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function xor(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function eq(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function eq(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function eq(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function ge(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function ge(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function ge(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function gt(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function gt(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function gt(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lte(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lte(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lte(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lt(euint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function lt(euint16 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lt(uint16 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
+    function add(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function add(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function add(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function sub(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function sub(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function sub(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function mul(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function mul(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function mul(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function and(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function and(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function and(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function or(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function or(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function or(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function xor(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function xor(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function xor(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function eq(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function eq(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function eq(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function ge(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function ge(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function ge(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function gt(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function gt(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function gt(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lte(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lte(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lte(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lt(euint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lt(euint32 a, uint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lt(uint32 a, euint8 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function add(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function add(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function add(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.add(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function sub(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function sub(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function sub(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.sub(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function mul(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function mul(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function mul(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.mul(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function and(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function and(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function and(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function or(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function or(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function or(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function xor(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function xor(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function xor(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function eq(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function eq(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function eq(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.eq(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function ge(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function ge(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function ge(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.ge(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function gt(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function gt(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function gt(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.gt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lte(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lte(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lte(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lte(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
+    }
+
+    function lt(euint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lt(euint32 a, uint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function lt(uint32 a, euint16 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.lt(
+                    euint32.unwrap(asEuint32(a)),
+                    euint32.unwrap(asEuint32(b))
+                )
+            );
     }
 
     function add(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.add(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function add(uint256 a, euint32 b) internal view returns (euint32) {
-        return add(asEuint32(a), b);
-    }
-
-    function add(euint32 a, uint256 b) internal view returns (euint32) {
-        return add(a, asEuint32(b));
-    }
-
     function sub(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.sub(euint32.unwrap(a), euint32.unwrap(b)));
-    }
-
-    function sub(uint256 a, euint32 b) internal view returns (euint32) {
-        return sub(asEuint32(a), b);
-    }
-
-    function sub(euint32 a, uint256 b) internal view returns (euint32) {
-        return sub(a, asEuint32(b));
     }
 
     function mul(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.mul(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function mul(uint256 a, euint32 b) internal view returns (euint32) {
-        return mul(asEuint32(a), b);
-    }
-
-    function mul(euint32 a, uint256 b) internal view returns (euint32) {
-        return mul(a, asEuint32(b));
-    }
-
     function and(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.and(euint32.unwrap(a), euint32.unwrap(b)));
-    }
-
-    function and(uint256 a, euint32 b) internal view returns (euint32) {
-        return and(asEuint32(a), b);
-    }
-
-    function and(euint32 a, uint256 b) internal view returns (euint32) {
-        return and(a, asEuint32(b));
     }
 
     function or(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.or(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function or(uint256 a, euint32 b) internal view returns (euint32) {
-        return or(asEuint32(a), b);
-    }
-
-    function or(euint32 a, uint256 b) internal view returns (euint32) {
-        return or(a, asEuint32(b));
-    }
-
     function xor(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
-    }
-
-    function xor(uint256 a, euint32 b) internal view returns (euint32) {
-        return xor(asEuint32(a), b);
-    }
-
-    function xor(euint32 a, uint256 b) internal view returns (euint32) {
-        return xor(a, asEuint32(b));
     }
 
     function eq(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.eq(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function eq(uint256 a, euint32 b) internal view returns (euint32) {
-        return eq(asEuint32(a), b);
-    }
-
-    function eq(euint32 a, uint256 b) internal view returns (euint32) {
-        return eq(a, asEuint32(b));
-    }
-
     function ge(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.ge(euint32.unwrap(a), euint32.unwrap(b)));
-    }
-
-    function ge(uint256 a, euint32 b) internal view returns (euint32) {
-        return ge(asEuint32(a), b);
-    }
-
-    function ge(euint32 a, uint256 b) internal view returns (euint32) {
-        return ge(a, asEuint32(b));
     }
 
     function gt(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.gt(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function gt(uint256 a, euint32 b) internal view returns (euint32) {
-        return gt(asEuint32(a), b);
-    }
-
-    function gt(euint32 a, uint256 b) internal view returns (euint32) {
-        return gt(a, asEuint32(b));
-    }
-
     function lte(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.lte(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function lte(uint256 a, euint32 b) internal view returns (euint32) {
-        return lte(asEuint32(a), b);
-    }
-
-    function lte(euint32 a, uint256 b) internal view returns (euint32) {
-        return lte(a, asEuint32(b));
-    }
-
     function lt(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.lt(euint32.unwrap(a), euint32.unwrap(b)));
-    }
-
-    function lt(uint256 a, euint32 b) internal view returns (euint32) {
-        return lt(asEuint32(a), b);
-    }
-
-    function lt(euint32 a, uint256 b) internal view returns (euint32) {
-        return lt(a, asEuint32(b));
     }
 
     function cmux(
@@ -418,14 +1738,14 @@ library TFHE {
     }
 
     function cmux(
-        euint8 control,
+        euint16 control,
         euint16 a,
         euint16 b
     ) internal view returns (euint16) {
         return
             euint16.wrap(
                 Impl.cmux(
-                    euint8.unwrap(control),
+                    euint16.unwrap(control),
                     euint16.unwrap(a),
                     euint16.unwrap(b)
                 )
@@ -433,14 +1753,14 @@ library TFHE {
     }
 
     function cmux(
-        euint8 control,
+        euint32 control,
         euint32 a,
         euint32 b
     ) internal view returns (euint32) {
         return
             euint32.wrap(
                 Impl.cmux(
-                    euint8.unwrap(control),
+                    euint32.unwrap(control),
                     euint32.unwrap(a),
                     euint32.unwrap(b)
                 )
@@ -505,7 +1825,7 @@ library TFHE {
     }
 
     function optimisticRequireCt(euint8 ciphertext) internal view {
-        Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
+        Impl.optimisticRequireCt(euint32.unwrap(asEuint32(ciphertext)));
     }
 
     function asEuint16(
@@ -530,7 +1850,7 @@ library TFHE {
     }
 
     function optimisticRequireCt(euint16 ciphertext) internal view {
-        Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
+        Impl.optimisticRequireCt(euint32.unwrap(asEuint32(ciphertext)));
     }
 
     function asEuint32(

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -42,6 +42,78 @@ library TFHE {
         return mul(a, asEuint8(b));
     }
 
+    function and(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function and(uint256 a, euint8 b) internal view returns (euint8) {
+        return and(asEuint8(a), b);
+    }
+
+    function and(euint8 a, uint256 b) internal view returns (euint8) {
+        return and(a, asEuint8(b));
+    }
+
+    function or(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function or(uint256 a, euint8 b) internal view returns (euint8) {
+        return or(asEuint8(a), b);
+    }
+
+    function or(euint8 a, uint256 b) internal view returns (euint8) {
+        return or(a, asEuint8(b));
+    }
+
+    function xor(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function xor(uint256 a, euint8 b) internal view returns (euint8) {
+        return xor(asEuint8(a), b);
+    }
+
+    function xor(euint8 a, uint256 b) internal view returns (euint8) {
+        return xor(a, asEuint8(b));
+    }
+
+    function eq(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function eq(uint256 a, euint8 b) internal view returns (euint8) {
+        return eq(asEuint8(a), b);
+    }
+
+    function eq(euint8 a, uint256 b) internal view returns (euint8) {
+        return eq(a, asEuint8(b));
+    }
+
+    function ge(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function ge(uint256 a, euint8 b) internal view returns (euint8) {
+        return ge(asEuint8(a), b);
+    }
+
+    function ge(euint8 a, uint256 b) internal view returns (euint8) {
+        return ge(a, asEuint8(b));
+    }
+
+    function gt(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function gt(uint256 a, euint8 b) internal view returns (euint8) {
+        return gt(asEuint8(a), b);
+    }
+
+    function gt(euint8 a, uint256 b) internal view returns (euint8) {
+        return gt(a, asEuint8(b));
+    }
+
     function lte(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.lte(euint8.unwrap(a), euint8.unwrap(b)));
     }
@@ -100,6 +172,78 @@ library TFHE {
 
     function mul(euint16 a, uint256 b) internal view returns (euint16) {
         return mul(a, asEuint16(b));
+    }
+
+    function and(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.and(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function and(uint256 a, euint16 b) internal view returns (euint16) {
+        return and(asEuint16(a), b);
+    }
+
+    function and(euint16 a, uint256 b) internal view returns (euint16) {
+        return and(a, asEuint16(b));
+    }
+
+    function or(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.or(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function or(uint256 a, euint16 b) internal view returns (euint16) {
+        return or(asEuint16(a), b);
+    }
+
+    function or(euint16 a, uint256 b) internal view returns (euint16) {
+        return or(a, asEuint16(b));
+    }
+
+    function xor(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function xor(uint256 a, euint16 b) internal view returns (euint16) {
+        return xor(asEuint16(a), b);
+    }
+
+    function xor(euint16 a, uint256 b) internal view returns (euint16) {
+        return xor(a, asEuint16(b));
+    }
+
+    function eq(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.eq(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function eq(uint256 a, euint16 b) internal view returns (euint16) {
+        return eq(asEuint16(a), b);
+    }
+
+    function eq(euint16 a, uint256 b) internal view returns (euint16) {
+        return eq(a, asEuint16(b));
+    }
+
+    function ge(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.ge(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function ge(uint256 a, euint16 b) internal view returns (euint16) {
+        return ge(asEuint16(a), b);
+    }
+
+    function ge(euint16 a, uint256 b) internal view returns (euint16) {
+        return ge(a, asEuint16(b));
+    }
+
+    function gt(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.gt(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function gt(uint256 a, euint16 b) internal view returns (euint16) {
+        return gt(asEuint16(a), b);
+    }
+
+    function gt(euint16 a, uint256 b) internal view returns (euint16) {
+        return gt(a, asEuint16(b));
     }
 
     function lte(euint16 a, euint16 b) internal view returns (euint16) {
@@ -162,6 +306,78 @@ library TFHE {
         return mul(a, asEuint32(b));
     }
 
+    function and(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.and(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function and(uint256 a, euint32 b) internal view returns (euint32) {
+        return and(asEuint32(a), b);
+    }
+
+    function and(euint32 a, uint256 b) internal view returns (euint32) {
+        return and(a, asEuint32(b));
+    }
+
+    function or(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.or(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function or(uint256 a, euint32 b) internal view returns (euint32) {
+        return or(asEuint32(a), b);
+    }
+
+    function or(euint32 a, uint256 b) internal view returns (euint32) {
+        return or(a, asEuint32(b));
+    }
+
+    function xor(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function xor(uint256 a, euint32 b) internal view returns (euint32) {
+        return xor(asEuint32(a), b);
+    }
+
+    function xor(euint32 a, uint256 b) internal view returns (euint32) {
+        return xor(a, asEuint32(b));
+    }
+
+    function eq(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.eq(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function eq(uint256 a, euint32 b) internal view returns (euint32) {
+        return eq(asEuint32(a), b);
+    }
+
+    function eq(euint32 a, uint256 b) internal view returns (euint32) {
+        return eq(a, asEuint32(b));
+    }
+
+    function ge(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.ge(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function ge(uint256 a, euint32 b) internal view returns (euint32) {
+        return ge(asEuint32(a), b);
+    }
+
+    function ge(euint32 a, uint256 b) internal view returns (euint32) {
+        return ge(a, asEuint32(b));
+    }
+
+    function gt(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.gt(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function gt(uint256 a, euint32 b) internal view returns (euint32) {
+        return gt(asEuint32(a), b);
+    }
+
+    function gt(euint32 a, uint256 b) internal view returns (euint32) {
+        return gt(a, asEuint32(b));
+    }
+
     function lte(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.lte(euint32.unwrap(a), euint32.unwrap(b)));
     }
@@ -186,40 +402,87 @@ library TFHE {
         return lt(a, asEuint32(b));
     }
 
-    function cmux(euint8 control, euint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.cmux(euint8.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint8 a,
+        euint8 b
+    ) internal view returns (euint8) {
+        return
+            euint8.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint8.unwrap(a),
+                    euint8.unwrap(b)
+                )
+            );
     }
 
-    function cmux(euint8 control, euint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.cmux(euint8.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint16 a,
+        euint16 b
+    ) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint16.unwrap(a),
+                    euint16.unwrap(b)
+                )
+            );
     }
 
-    function cmux(euint8 control, euint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.cmux(euint8.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
+    function cmux(
+        euint8 control,
+        euint32 a,
+        euint32 b
+    ) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.cmux(
+                    euint8.unwrap(control),
+                    euint32.unwrap(a),
+                    euint32.unwrap(b)
+                )
+            );
     }
 
     function asEuint8(euint16 ciphertext) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
+        return
+            euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
     }
 
     function asEuint8(euint32 ciphertext) internal view returns (euint8) {
-        return euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
+        return
+            euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
     }
 
     function asEuint16(euint8 ciphertext) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t));
+        return
+            euint16.wrap(
+                Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t)
+            );
     }
 
     function asEuint16(euint32 ciphertext) internal view returns (euint16) {
-        return euint16.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t));
+        return
+            euint16.wrap(
+                Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t)
+            );
     }
 
     function asEuint32(euint8 ciphertext) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t));
+        return
+            euint32.wrap(
+                Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t)
+            );
     }
 
     function asEuint32(euint16 ciphertext) internal view returns (euint32) {
-        return euint32.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t));
+        return
+            euint32.wrap(
+                Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t)
+            );
     }
 
     function asEuint8(bytes memory ciphertext) internal view returns (euint8) {
@@ -230,7 +493,10 @@ library TFHE {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.euint8_t));
     }
 
-    function reencrypt(euint8 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint8 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
 
@@ -242,7 +508,9 @@ library TFHE {
         Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
     }
 
-    function asEuint16(bytes memory ciphertext) internal view returns (euint16) {
+    function asEuint16(
+        bytes memory ciphertext
+    ) internal view returns (euint16) {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
@@ -250,7 +518,10 @@ library TFHE {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.euint16_t));
     }
 
-    function reencrypt(euint16 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint16 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
 
@@ -262,7 +533,9 @@ library TFHE {
         Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
-    function asEuint32(bytes memory ciphertext) internal view returns (euint32) {
+    function asEuint32(
+        bytes memory ciphertext
+    ) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
     }
 
@@ -270,7 +543,10 @@ library TFHE {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.euint32_t));
     }
 
-    function reencrypt(euint32 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+    function reencrypt(
+        euint32 ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }
 

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -42,8 +42,8 @@ library TFHE {
         return euint8.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function lte(euint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.lte(euint8.unwrap(a), euint8.unwrap(b)));
+    function le(euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
     function lt(euint8 a, euint8 b) internal view returns (euint8) {
@@ -266,27 +266,27 @@ library TFHE {
             );
     }
 
-    function lte(euint8 a, euint16 b) internal view returns (euint16) {
+    function le(euint8 a, euint16 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+                Impl.le(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
             );
     }
 
-    function lte(euint8 a, uint16 b) internal view returns (euint16) {
+    function le(euint8 a, uint16 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(
+                Impl.le(
                     euint16.unwrap(asEuint16(a)),
                     euint16.unwrap(asEuint16(b))
                 )
             );
     }
 
-    function lte(uint8 a, euint16 b) internal view returns (euint16) {
+    function le(uint8 a, euint16 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+                Impl.le(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
             );
     }
 
@@ -530,27 +530,27 @@ library TFHE {
             );
     }
 
-    function lte(euint8 a, euint32 b) internal view returns (euint32) {
+    function le(euint8 a, euint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
             );
     }
 
-    function lte(euint8 a, uint32 b) internal view returns (euint32) {
+    function le(euint8 a, uint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(
+                Impl.le(
                     euint32.unwrap(asEuint32(a)),
                     euint32.unwrap(asEuint32(b))
                 )
             );
     }
 
-    function lte(uint8 a, euint32 b) internal view returns (euint32) {
+    function le(uint8 a, euint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
             );
     }
 
@@ -794,24 +794,24 @@ library TFHE {
             );
     }
 
-    function lte(euint16 a, euint8 b) internal view returns (euint16) {
+    function le(euint16 a, euint8 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+                Impl.le(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
             );
     }
 
-    function lte(euint16 a, uint8 b) internal view returns (euint16) {
+    function le(euint16 a, uint8 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+                Impl.le(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
             );
     }
 
-    function lte(uint16 a, euint8 b) internal view returns (euint16) {
+    function le(uint16 a, euint8 b) internal view returns (euint16) {
         return
             euint16.wrap(
-                Impl.lte(
+                Impl.le(
                     euint16.unwrap(asEuint16(a)),
                     euint16.unwrap(asEuint16(b))
                 )
@@ -878,8 +878,8 @@ library TFHE {
         return euint16.wrap(Impl.gt(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function lte(euint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.lte(euint16.unwrap(a), euint16.unwrap(b)));
+    function le(euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.le(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
     function lt(euint16 a, euint16 b) internal view returns (euint16) {
@@ -1102,27 +1102,27 @@ library TFHE {
             );
     }
 
-    function lte(euint16 a, euint32 b) internal view returns (euint32) {
+    function le(euint16 a, euint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
             );
     }
 
-    function lte(euint16 a, uint32 b) internal view returns (euint32) {
+    function le(euint16 a, uint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(
+                Impl.le(
                     euint32.unwrap(asEuint32(a)),
                     euint32.unwrap(asEuint32(b))
                 )
             );
     }
 
-    function lte(uint16 a, euint32 b) internal view returns (euint32) {
+    function le(uint16 a, euint32 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
             );
     }
 
@@ -1366,24 +1366,24 @@ library TFHE {
             );
     }
 
-    function lte(euint32 a, euint8 b) internal view returns (euint32) {
+    function le(euint32 a, euint8 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
             );
     }
 
-    function lte(euint32 a, uint8 b) internal view returns (euint32) {
+    function le(euint32 a, uint8 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
             );
     }
 
-    function lte(uint32 a, euint8 b) internal view returns (euint32) {
+    function le(uint32 a, euint8 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(
+                Impl.le(
                     euint32.unwrap(asEuint32(a)),
                     euint32.unwrap(asEuint32(b))
                 )
@@ -1630,24 +1630,24 @@ library TFHE {
             );
     }
 
-    function lte(euint32 a, euint16 b) internal view returns (euint32) {
+    function le(euint32 a, euint16 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
             );
     }
 
-    function lte(euint32 a, uint16 b) internal view returns (euint32) {
+    function le(euint32 a, uint16 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
             );
     }
 
-    function lte(uint32 a, euint16 b) internal view returns (euint32) {
+    function le(uint32 a, euint16 b) internal view returns (euint32) {
         return
             euint32.wrap(
-                Impl.lte(
+                Impl.le(
                     euint32.unwrap(asEuint32(a)),
                     euint32.unwrap(asEuint32(b))
                 )
@@ -1714,8 +1714,8 @@ library TFHE {
         return euint32.wrap(Impl.gt(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function lte(euint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lte(euint32.unwrap(a), euint32.unwrap(b)));
+    function le(euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.le(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
     function lt(euint32 a, euint32 b) internal view returns (euint32) {

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -186,49 +186,40 @@ library TFHE {
         return lt(a, asEuint32(b));
     }
 
-    function cmux(
-        euint8 control,
-        euint8 a,
-        euint8 b
-    ) internal view returns (euint8) {
-        return
-            euint8.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint8.unwrap(a),
-                    euint8.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint8 a, euint8 b) internal view returns (euint8) {
+        return euint8.wrap(Impl.cmux(euint8.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint16 a,
-        euint16 b
-    ) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint16.unwrap(a),
-                    euint16.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint16 a, euint16 b) internal view returns (euint16) {
+        return euint16.wrap(Impl.cmux(euint8.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function cmux(
-        euint8 control,
-        euint32 a,
-        euint32 b
-    ) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.cmux(
-                    euint8.unwrap(control),
-                    euint32.unwrap(a),
-                    euint32.unwrap(b)
-                )
-            );
+    function cmux(euint8 control, euint32 a, euint32 b) internal view returns (euint32) {
+        return euint32.wrap(Impl.cmux(euint8.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function asEuint8(euint16 ciphertext) internal view returns (euint8) {
+        return euint8.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint8_t));
+    }
+
+    function asEuint8(euint32 ciphertext) internal view returns (euint8) {
+        return euint8.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint8_t));
+    }
+
+    function asEuint16(euint8 ciphertext) internal view returns (euint16) {
+        return euint16.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint16_t));
+    }
+
+    function asEuint16(euint32 ciphertext) internal view returns (euint16) {
+        return euint16.wrap(Impl.cast(euint32.unwrap(ciphertext), Common.euint16_t));
+    }
+
+    function asEuint32(euint8 ciphertext) internal view returns (euint32) {
+        return euint32.wrap(Impl.cast(euint8.unwrap(ciphertext), Common.euint32_t));
+    }
+
+    function asEuint32(euint16 ciphertext) internal view returns (euint32) {
+        return euint32.wrap(Impl.cast(euint16.unwrap(ciphertext), Common.euint32_t));
     }
 
     function asEuint8(bytes memory ciphertext) internal view returns (euint8) {
@@ -239,10 +230,7 @@ library TFHE {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.euint8_t));
     }
 
-    function reencrypt(
-        euint8 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint8 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint8.unwrap(ciphertext), publicKey);
     }
 
@@ -254,9 +242,7 @@ library TFHE {
         Impl.optimisticRequireCt(euint8.unwrap(ciphertext));
     }
 
-    function asEuint16(
-        bytes memory ciphertext
-    ) internal view returns (euint16) {
+    function asEuint16(bytes memory ciphertext) internal view returns (euint16) {
         return euint16.wrap(Impl.verify(ciphertext, Common.euint16_t));
     }
 
@@ -264,10 +250,7 @@ library TFHE {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.euint16_t));
     }
 
-    function reencrypt(
-        euint16 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint16 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint16.unwrap(ciphertext), publicKey);
     }
 
@@ -279,9 +262,7 @@ library TFHE {
         Impl.optimisticRequireCt(euint16.unwrap(ciphertext));
     }
 
-    function asEuint32(
-        bytes memory ciphertext
-    ) internal view returns (euint32) {
+    function asEuint32(bytes memory ciphertext) internal view returns (euint32) {
         return euint32.wrap(Impl.verify(ciphertext, Common.euint32_t));
     }
 
@@ -289,10 +270,7 @@ library TFHE {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.euint32_t));
     }
 
-    function reencrypt(
-        euint32 ciphertext,
-        bytes32 publicKey
-    ) internal view returns (bytes memory reencrypted) {
+    function reencrypt(euint32 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
         return Impl.reencrypt(euint32.unwrap(ciphertext), publicKey);
     }
 


### PR DESCRIPTION
Closes #45. Adds `&`, `|`, `^`, `==`, `>`, and `>=` to the list of binary operators exposed by the library,