### PR TITLE
Update EncryptedERC20.sol

### DIFF
--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -58,8 +58,7 @@ contract EncryptedERC20 is EIP712WithModifier {
         return TFHE.reencrypt(totalSupply, publicKey);
     }
 
-    // Returns the balance of the caller under their public FHE key.
-    // The FHE public key is automatically determined based on the origin of the call.
+    // Returns the balance of the caller under the provided public key.
     function balanceOf(
         bytes32 publicKey,
         bytes calldata signature

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -58,7 +58,7 @@ contract EncryptedERC20 is EIP712WithModifier {
         return TFHE.reencrypt(totalSupply, publicKey);
     }
 
-    // Returns the balance of the caller under the provided public key.
+    // Returns the balance of the caller encrypted under the provided public key.
     function balanceOf(
         bytes32 publicKey,
         bytes calldata signature


### PR DESCRIPTION
Remove the comment indicating that a user's balance is re-encrypted under its FHE public key, which is automatically determined (this is not true anymore).