### PR TITLE
package() prepare repository for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*
+!lib/*
+!package.json
+!README.md
+!LICENSE

--- a/README.md
+++ b/README.md
@@ -1,18 +1,57 @@
-# zbc-solidity
+# fhEVM
 
 A Solidity library for interacting with the Zama Blockchain
 
-# Development guide
+## Install
+
+```bash
+npm install fhevm
+```
+
+or
+
+```bash
+yarn install fhevm
+```
+
+## Usage
+
+```solidity
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity >=0.8.13 <0.9.0;
+
+import "fhevm/lib/TFHE.sol";
+
+contract Counter {
+  euint32 counter;
+
+  constructor() {}
+
+  function add(bytes calldata encryptedValue) public {
+    euint32 value = TFHE.asEuint32(encryptedValue);
+    counter = TFHE.add(world, value);
+  }
+
+  function getCounter(bytes32 publicKey) returns (bytes memory) {
+    return TFHE.reencrypt(totalSupply, publicKey);
+  }
+}
+```
+
+See our documentation on [https://docs.zama.ai/homepage/](https://docs.zama.ai/homepage/) for more examples.
+
+## Development Guide
 
 Install dependencies (Solidity libraries and dev tools)
 
-```
+```bash
 npm install
 ```
 
 Note: Solidity files are formatted with prettier.
 
-## Generate TFHE lib
+### Generate TFHE lib
 
 ```
 npm run codegen
@@ -20,29 +59,27 @@ npm run codegen
 
 WARNING: Use this command to generate Solidity code and prettier result automatically!
 
-# Demo Test
+### Demo Test
 
 This repository includes a python script (see [demo_test.py](demo_test.py)) that automates a sequence of steps simulating deployment and interaction with an encrypted ERC20 contract.
 
 Because inputs must be encrypted using the blockchain global public key, a tool called zbc-fhe-tool is available.
 
-We also need the blockchain public key, please copy it into __keys/network-public-fhe-keys/__ named __pks__.
-
+We also need the blockchain public key, please copy it into **keys/network-public-fhe-keys/** named **pks**.
 
 The python script accepts two arguments:
+
 1. The private key of the main account which owns funds
 2. [optionnal --node_address] The node @ (default is http://host.docker.internal:8545)
 
 To install all the required python modules, a docker is available containing zbc-fhe-tool binary.
 
 Run the demo test:
+
 ```
 export PRIVATE_KEY=CCABB56366...
 docker compose -f ci/docker-compose.yml run app python demo_test.py $PRIVATE_KEY
 ```
-
-
-
 
 <br />
 <details>
@@ -53,7 +90,7 @@ docker compose -f ci/docker-compose.yml run app python demo_test.py $PRIVATE_KEY
 make install-zbc-fhe-tool
 ```
 
-#The binary will be available at __work_dir/zbc-fhe-tool/target/release/zbc-fhe-tool__
+#The binary will be available at **work_dir/zbc-fhe-tool/target/release/zbc-fhe-tool**
+
 </details>
 <br />
-

--- a/demo_test.py
+++ b/demo_test.py
@@ -149,6 +149,8 @@ compiled_sol = compile_standard(
         "language": "Solidity",
         "sources": {"EncryptedERC20.sol": {"content": file_contents}},
         "settings": {
+            "remappings": [ '@openzeppelin/contracts={0}/node_modules/@openzeppelin/contracts'.format(os.getcwd()),
+                            'abstract={0}/examples/abstract'.format(os.getcwd()) ],
             "outputSelection": {
                 "*": {
                     "*": ["abi", "metadata", "evm.bytecode", "evm.bytecode.sourceMap"]
@@ -156,8 +158,7 @@ compiled_sol = compile_standard(
             }
         },
     },
-    solc_version="0.8.13",
-    allow_paths="./examples"
+    solc_version="0.8.13"
 )
 print('Contract compilation took %s seconds' % (time.time() - start))
 

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -2,7 +2,7 @@
 
 pragma solidity >=0.8.13 <0.9.0;
 
-import "./examples/abstract/EIP712WithModifier.sol";
+import "./abstract/EIP712WithModifier.sol";
 
 import "../lib/TFHE.sol";
 

--- a/examples/abstract/EIP712WithModifier.sol
+++ b/examples/abstract/EIP712WithModifier.sol
@@ -2,8 +2,8 @@
 
 pragma solidity >=0.8.13 <0.9.0;
 
-import "../../node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "../../node_modules/@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
 abstract contract EIP712WithModifier is EIP712 {
     constructor(

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "zbc-solidity",
+  "name": "fhevm",
   "description": "A Solidity library for interacting with the Zama Blockchain",
-  "version": "1.0.0",
-  "main": "index.js",
+  "version": "0.0.1",
+  "main": "lib/TFHE.sol",
   "directories": {
     "example": "examples",
     "lib": "lib"


### PR DESCRIPTION
- Updated README and package.json to publish on NPM
- Updated paths for correct import in VSCode or Remix IDE
- I change the demo_test.py to allow import: it seems to work locally, but it would be nice to check the full chain with the modification. It seems the docker image doesn’t work on M1, so I just tested locally by executing the python script. @leventdem 