### PR TITLE
fix(impl): fix mul bug

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -138,12 +138,6 @@ library Impl {
     }
 
     function mul(uint256 a, uint256 b, bool scalar) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-        
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -107,12 +107,6 @@ library Impl {
         uint256 b,
         bool scalar
     ) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;


### PR DESCRIPTION
Fix bug where `mul` would return a wrong result in the case where one of the two operands is `0`. 