### PR TITLE
fix(tfhe): add missing overloads

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -789,6 +789,14 @@ to_print_no_scalar_no_cast = """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b)));
     }}
+
+    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(asEuint{j}(b))));
+    }}
+
+    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(asEuint{i}(a)), euint{j}.unwrap(b)));
+    }}
 """
 
 to_print_no_scalar_cast_a = """

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -34,12 +34,42 @@ library TFHE {
         return euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
+    function and(euint8 a, uint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
+    }
+
+    function and(uint8 a, euint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.and(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
+    }
+
     function or(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
+    function or(euint8 a, uint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
+    }
+
+    function or(uint8 a, euint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.or(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
+    }
+
     function xor(euint8 a, euint8 b) internal view returns (euint8) {
         return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
+    }
+
+    function xor(euint8 a, uint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
+    }
+
+    function xor(uint8 a, euint8 b) internal view returns (euint8) {
+        return
+            euint8.wrap(Impl.xor(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
     }
 
     function shl(euint8 a, euint8 b) internal view returns (euint8) {
@@ -1019,12 +1049,54 @@ library TFHE {
         return euint16.wrap(Impl.and(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
+    function and(euint16 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function and(uint16 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
     function or(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.or(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
+    function or(euint16 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function or(uint16 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
+    }
+
     function xor(euint16 a, euint16 b) internal view returns (euint16) {
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
+    }
+
+    function xor(euint16 a, uint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
+            );
+    }
+
+    function xor(uint16 a, euint16 b) internal view returns (euint16) {
+        return
+            euint16.wrap(
+                Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
+            );
     }
 
     function shl(euint16 a, euint16 b) internal view returns (euint16) {
@@ -2014,12 +2086,54 @@ library TFHE {
         return euint32.wrap(Impl.and(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
+    function and(euint32 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function and(uint32 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
     function or(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.or(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
+    function or(euint32 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function or(uint32 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
+    }
+
     function xor(euint32 a, euint32 b) internal view returns (euint32) {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
+    }
+
+    function xor(euint32 a, uint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
+            );
+    }
+
+    function xor(uint32 a, euint32 b) internal view returns (euint32) {
+        return
+            euint32.wrap(
+                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
+            );
     }
 
     function shl(euint32 a, euint32 b) internal view returns (euint32) {


### PR DESCRIPTION
Add missing overloads for on ciphertext/plaintext bitwise ops of same bit width :)