### PR TITLE
fix(tfhe): add automatic initialization for ciphertexts

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -75,12 +75,6 @@ library Impl {
     uint256 constant fhePubKeySize = 32 + 16553;
 
     function add(uint256 a, uint256 b, bool scalar) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-        
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;
@@ -107,12 +101,6 @@ library Impl {
     }
 
     function sub(uint256 a, uint256 b, bool scalar) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-        
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;
@@ -744,144 +732,162 @@ f.write(to_print_is_initialized.format(i=8))
 f.write(to_print_is_initialized.format(i=16))
 f.write(to_print_is_initialized.format(i=32))
 
-
 to_print_no_cast =  """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b), false));
-    }}
-
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), uint256(b), true));
-    }}
-
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{g}(euint{j}.unwrap(b), uint256(a), true));
     }}
 """
 
 to_print_cast_a =  """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b), false));
-    }}
-
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), uint256(b), true));
-    }}
-
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{g}(euint{j}.unwrap(b), uint256(a), true));
     }}
 """
 
 to_print_cast_b =  """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b)), false));
-    }}
-
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), uint256(b), true));
-    }}
-
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{g}(euint{i}.unwrap(asEuint{i}(b)), uint256(a), true));
     }}
 """
 
 to_print_no_scalar_no_cast = """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b)));
-    }}
-
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(asEuint{j}(b))));
-    }}
-
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(asEuint{i}(a)), euint{j}.unwrap(b)));
     }}
 """
 
 to_print_no_scalar_cast_a = """
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b)));
-    }}
-
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(asEuint{j}(b))));
-    }}
-
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b)));
     }}
 """
 
 to_print_no_scalar_cast_b = """
 function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
         return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b))));
     }}
+"""
 
-    function {f}(euint{i} a, uint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b))));
+to_print_scalar = """
+    function {f}(euint{i} a, uint{i} b) internal view returns (euint{i}) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        return euint{i}.wrap(Impl.{f}(euint{i}.unwrap(a), uint256(b), true));
     }}
 
-    function {f}(uint{i} a, euint{j} b) internal view returns (euint{k}) {{
-        return euint{k}.wrap(Impl.{f}(euint{i}.unwrap(asEuint{i}(a)), euint{i}.unwrap(asEuint{i}(b))));
+    function {f}(uint{i} a, euint{i} b) internal view returns (euint{i}) {{
+        if (!isInitialized(b)) {{
+            b = asEuint{i}(0);
+        }}
+        return euint{i}.wrap(Impl.{g}(euint{i}.unwrap(b), uint256(a), true));
     }}
 """
 
 for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
         if i == j:
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="add", g="add")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="sub", g="sub")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="mul", g="mul")))
-            f.write((to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="and")))
-            f.write((to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="or")))
-            f.write((to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="xor")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="shl", g="shl")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="shr", g="shr")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="eq", g="eq")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="ne", g="ne")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="ge", g="le")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="gt", g="lt")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="le", g="ge")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="lt", g="gt")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="min", g="min")))
-            f.write((to_print_no_cast.format(i=i, j=j, k=i, f="max", g="max")))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="add", g="add"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="sub", g="sub"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="mul", g="mul"))
+            f.write(to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="and"))
+            f.write(to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="or"))
+            f.write(to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="xor"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="shl", g="shl"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="shr", g="shr"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="eq", g="eq"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="ne", g="ne"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="ge", g="le"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="gt", g="lt"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="le", g="ge"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="lt", g="gt"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="min", g="min"))
+            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="max", g="max"))
         elif i < j:
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="add", g="add")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="sub", g="sub")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="mul", g="mul")))
-            f.write((to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="and")))
-            f.write((to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="or")))
-            f.write((to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="xor")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="shl", g="shl")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="shr", g="shr")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="eq", g="eq")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="ne", g="ne")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="ge", g="le")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="gt", g="lt")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="le", g="ge")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="lt", g="gt")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="min", g="min")))
-            f.write((to_print_cast_a.format(i=i, j=j, k=j, f="max", g="max")))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="add", g="add"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="sub", g="sub"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="mul", g="mul"))
+            f.write(to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="and"))
+            f.write(to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="or"))
+            f.write(to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="xor"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="shl", g="shl"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="shr", g="shr"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="eq", g="eq"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="ne", g="ne"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="ge", g="le"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="gt", g="lt"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="le", g="ge"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="lt", g="gt"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="min", g="min"))
+            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="max", g="max"))
         else:
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="add", g="add")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="sub", g="sub")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="mul", g="mul")))
-            f.write((to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="and")))
-            f.write((to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="or")))
-            f.write((to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="xor")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="shl", g="shl")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="shr", g="shr")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="eq", g="eq")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="ne", g="ne")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="ge", g="le")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="gt", g="lt")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="le", g="ge")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="lt", g="gt")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="min", g="min")))
-            f.write((to_print_cast_b.format(i=i, j=j, k=i, f="max", g="max")))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="add", g="add"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="sub", g="sub"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="mul", g="mul"))
+            f.write(to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="and"))
+            f.write(to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="or"))
+            f.write(to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="xor"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="shl", g="shl"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="shr", g="shr"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="eq", g="eq"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="ne", g="ne"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="ge", g="le"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="gt", g="lt"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="le", g="ge"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="lt", g="gt"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="min", g="min"))
+            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="max", g="max"))
+    f.write(to_print_scalar.format(i=i, f="add", g="add"))
+    f.write(to_print_scalar.format(i=i, f="sub", g="sub"))
+    f.write(to_print_scalar.format(i=i, f="mul", g="mul"))
+    f.write(to_print_scalar.format(i=i, f="shl", g="shl"))
+    f.write(to_print_scalar.format(i=i, f="shr", g="shr"))
+    f.write(to_print_scalar.format(i=i, f="eq", g="eq"))
+    f.write(to_print_scalar.format(i=i, f="ne", g="ne"))
+    f.write(to_print_scalar.format(i=i, f="ge", g="le"))
+    f.write(to_print_scalar.format(i=i, f="gt", g="lt"))
+    f.write(to_print_scalar.format(i=i, f="le", g="ge"))
+    f.write(to_print_scalar.format(i=i, f="lt", g="gt"))
+    f.write(to_print_scalar.format(i=i, f="min", g="min"))
+    f.write(to_print_scalar.format(i=i, f="max", g="max"))
+
+
 to_print =  """
     function cmux(euint{i} control, euint{i} a, euint{i} b) internal view returns (euint{i}) {{
         return euint{i}.wrap(Impl.cmux(euint{i}.unwrap(control), euint{i}.unwrap(a), euint{i}.unwrap(b)));

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -18,12 +18,6 @@ library Impl {
         uint256 b,
         bool scalar
     ) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;
@@ -63,12 +57,6 @@ library Impl {
         uint256 b,
         bool scalar
     ) internal view returns (uint256 result) {
-        if (a == 0) {
-            return b;
-        } else if (b == 0) {
-            return a;
-        }
-
         bytes1 scalarByte;
         if (scalar) {
             scalarByte = 0x01;

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -19,275 +19,211 @@ library TFHE {
     }
 
     function add(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.add(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function add(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.add(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.add(euint8.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.sub(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function sub(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.sub(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.sub(euint8.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.mul(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function mul(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.mul(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.mul(euint8.unwrap(b), uint256(a), true));
-    }
-
     function and(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function and(euint8 a, uint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.and(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
-    }
-
-    function and(uint8 a, euint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.and(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
-    }
-
     function or(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function or(euint8 a, uint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.or(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
-    }
-
-    function or(uint8 a, euint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.or(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
-    }
-
     function xor(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    function xor(euint8 a, uint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(asEuint8(b))));
-    }
-
-    function xor(uint8 a, euint8 b) internal view returns (euint8) {
-        return
-            euint8.wrap(Impl.xor(euint8.unwrap(asEuint8(a)), euint8.unwrap(b)));
-    }
-
     function shl(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.shl(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function shl(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.shl(euint8.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function shr(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.shr(euint8.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function eq(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.eq(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.eq(euint8.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.ne(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function ne(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.ne(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.ne(euint8.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function ge(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.ge(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.le(euint8.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function gt(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.gt(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.lt(euint8.unwrap(b), uint256(a), true));
-    }
-
     function le(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function le(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.le(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.ge(euint8.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function lt(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.lt(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.gt(euint8.unwrap(b), uint256(a), true));
-    }
-
     function min(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.min(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function min(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.min(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.min(euint8.unwrap(b), uint256(a), true));
-    }
-
     function max(euint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return euint8.wrap(Impl.max(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
-    function max(euint8 a, uint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.max(euint8.unwrap(a), uint256(b), true));
-    }
-
-    function max(uint8 a, euint8 b) internal view returns (euint8) {
-        return euint8.wrap(Impl.max(euint8.unwrap(b), uint256(a), true));
-    }
-
     function add(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.add(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function add(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.add(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function add(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.add(euint16.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.sub(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function sub(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.sub(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function sub(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.sub(euint16.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.mul(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function mul(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.mul(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function mul(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.mul(euint16.unwrap(b), uint256(a), true));
-    }
-
     function and(euint8 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
-    function and(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
-            );
-    }
-
-    function and(uint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
@@ -295,23 +231,12 @@ library TFHE {
     }
 
     function or(euint8 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
-    function or(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
-            );
-    }
-
-    function or(uint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
@@ -319,23 +244,12 @@ library TFHE {
     }
 
     function xor(euint8 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
-    function xor(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
-            );
-    }
-
-    function xor(uint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
@@ -343,257 +257,181 @@ library TFHE {
     }
 
     function shl(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.shl(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function shl(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.shl(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function shl(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.shr(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function shr(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.shr(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function shr(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shr(euint16.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.eq(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function eq(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.eq(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function eq(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.eq(euint16.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.ne(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function ne(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.ne(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function ne(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ne(euint16.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.ge(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function ge(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.ge(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function ge(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.le(euint16.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.gt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function gt(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.gt(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function gt(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.lt(euint16.unwrap(b), uint256(a), true));
-    }
-
     function le(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.le(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function le(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.le(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function le(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ge(euint16.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.lt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function lt(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.lt(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function lt(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.gt(euint16.unwrap(b), uint256(a), true));
-    }
-
     function min(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.min(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function min(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.min(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function min(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.min(euint16.unwrap(b), uint256(a), true));
-    }
-
     function max(euint8 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(
                 Impl.max(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
             );
     }
 
-    function max(euint8 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.max(euint16.unwrap(asEuint16(a)), uint256(b), true)
-            );
-    }
-
-    function max(uint8 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.max(euint16.unwrap(b), uint256(a), true));
-    }
-
     function add(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function add(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.add(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function add(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function sub(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.sub(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function sub(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function mul(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.mul(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function mul(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
-    }
-
     function and(euint8 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function and(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function and(uint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -601,23 +439,12 @@ library TFHE {
     }
 
     function or(euint8 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function or(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function or(uint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -625,23 +452,12 @@ library TFHE {
     }
 
     function xor(euint8 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function xor(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function xor(uint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -649,786 +465,744 @@ library TFHE {
     }
 
     function shl(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function shl(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shl(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function shl(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function shr(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shr(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function shr(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function eq(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function eq(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.ne(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function ne(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function ne(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function ge(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function ge(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function gt(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function gt(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function le(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function le(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function le(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function lt(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function lt(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function min(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.min(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function min(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.min(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function min(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(b), uint256(a), true));
-    }
-
     function max(euint8 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function max(euint8 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.max(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
+    function add(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.add(euint8.unwrap(a), uint256(b), true));
     }
 
-    function max(uint8 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
+    function add(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.add(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function sub(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.sub(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function sub(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.sub(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function mul(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.mul(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function mul(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.mul(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function shl(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function shl(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function shr(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function shr(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function eq(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.eq(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function eq(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.eq(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function ne(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.ne(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function ne(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.ne(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function ge(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.ge(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function ge(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.le(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function gt(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.gt(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function gt(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.lt(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function le(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.le(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function le(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.ge(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function lt(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.lt(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function lt(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.gt(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function min(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.min(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function min(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.min(euint8.unwrap(b), uint256(a), true));
+    }
+
+    function max(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.max(euint8.unwrap(a), uint256(b), true));
+    }
+
+    function max(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.max(euint8.unwrap(b), uint256(a), true));
     }
 
     function add(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.add(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function add(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.add(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.add(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function sub(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.sub(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function sub(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.sub(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.sub(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function mul(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.mul(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function mul(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.mul(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.mul(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function and(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function and(euint16 a, uint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function and(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
             );
     }
 
     function or(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function or(euint16 a, uint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function or(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
             );
     }
 
     function xor(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function xor(euint16 a, uint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function xor(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(
-                    euint16.unwrap(asEuint16(a)),
-                    euint16.unwrap(asEuint16(b))
-                )
             );
     }
 
     function shl(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.shl(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function shl(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.shl(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function shr(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.shr(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function shr(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.shr(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function eq(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.eq(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function eq(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.eq(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.eq(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function ne(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.ne(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function ne(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ne(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.ne(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function ge(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.ge(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function ge(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ge(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.le(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function gt(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.gt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function gt(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.gt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.lt(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function le(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.le(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function le(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.le(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.ge(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function lt(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.lt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function lt(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.lt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.gt(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function min(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.min(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function min(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.min(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.min(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function max(euint16 a, euint8 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint16.wrap(
                 Impl.max(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
             );
     }
 
-    function max(euint16 a, uint8 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.max(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function max(uint16 a, euint8 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.max(euint16.unwrap(asEuint16(b)), uint256(a), true)
-            );
-    }
-
     function add(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.add(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function add(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.add(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.add(euint16.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.sub(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function sub(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.sub(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.sub(euint16.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.mul(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function mul(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.mul(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.mul(euint16.unwrap(b), uint256(a), true));
-    }
-
     function and(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return euint16.wrap(Impl.and(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function and(euint16 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function and(uint16 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.and(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
     function or(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return euint16.wrap(Impl.or(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function or(euint16 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function or(uint16 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.or(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
     function xor(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
     }
 
-    function xor(euint16 a, uint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b)))
-            );
-    }
-
-    function xor(uint16 a, euint16 b) internal view returns (euint16) {
-        return
-            euint16.wrap(
-                Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b))
-            );
-    }
-
     function shl(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function shl(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function shr(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.shr(euint16.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.eq(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function eq(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.eq(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.eq(euint16.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.ne(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function ne(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ne(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ne(euint16.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.ge(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function ge(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ge(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.le(euint16.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.gt(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function gt(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.gt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.lt(euint16.unwrap(b), uint256(a), true));
-    }
-
     function le(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.le(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function le(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.le(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.ge(euint16.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.lt(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function lt(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.lt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.gt(euint16.unwrap(b), uint256(a), true));
-    }
-
     function min(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.min(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function min(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.min(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.min(euint16.unwrap(b), uint256(a), true));
-    }
-
     function max(euint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint16.wrap(Impl.max(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
-    function max(euint16 a, uint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.max(euint16.unwrap(a), uint256(b), true));
-    }
-
-    function max(uint16 a, euint16 b) internal view returns (euint16) {
-        return euint16.wrap(Impl.max(euint16.unwrap(b), uint256(a), true));
-    }
-
     function add(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.add(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function add(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.add(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function add(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.sub(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function sub(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.sub(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function sub(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.mul(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function mul(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.mul(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function mul(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
-    }
-
     function and(euint16 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function and(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function and(uint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -1436,23 +1210,12 @@ library TFHE {
     }
 
     function or(euint16 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function or(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function or(uint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -1460,23 +1223,12 @@ library TFHE {
     }
 
     function xor(euint16 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
-    function xor(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
-            );
-    }
-
-    function xor(uint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
@@ -1484,1017 +1236,1085 @@ library TFHE {
     }
 
     function shl(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function shl(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shl(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function shl(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function shr(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shr(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function shr(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function eq(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function eq(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.ne(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function ne(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function ne(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function ge(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function ge(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function gt(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function gt(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function le(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function le(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function le(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function lt(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function lt(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function min(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.min(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function min(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.min(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
-    }
-
-    function min(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(b), uint256(a), true));
-    }
-
     function max(euint16 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
     }
 
-    function max(euint16 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.max(euint32.unwrap(asEuint32(a)), uint256(b), true)
-            );
+    function add(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.add(euint16.unwrap(a), uint256(b), true));
     }
 
-    function max(uint16 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
+    function add(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.add(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function sub(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.sub(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function sub(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.sub(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function mul(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.mul(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function mul(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.mul(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function shl(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function shl(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function shr(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function shr(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function eq(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.eq(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function eq(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.eq(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function ne(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.ne(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function ne(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.ne(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function ge(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.ge(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function ge(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.le(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function gt(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.gt(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function gt(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.lt(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function le(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.le(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function le(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.ge(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function lt(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.lt(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function lt(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.gt(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function min(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.min(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function min(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.min(euint16.unwrap(b), uint256(a), true));
+    }
+
+    function max(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.max(euint16.unwrap(a), uint256(b), true));
+    }
+
+    function max(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.max(euint16.unwrap(b), uint256(a), true));
     }
 
     function add(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
-            );
-    }
-
-    function add(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.add(euint32.unwrap(asEuint32(b)), uint256(a), true)
             );
     }
 
     function sub(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function sub(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.sub(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function mul(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function mul(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.mul(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function and(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function and(euint32 a, uint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function and(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function or(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function or(euint32 a, uint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function or(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function xor(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function xor(euint32 a, uint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function xor(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function shl(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function shl(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shl(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function shr(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function shr(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shr(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function eq(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function eq(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function ne(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.ne(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function ne(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function ge(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function ge(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function gt(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function gt(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function le(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function le(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function lt(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function lt(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function min(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.min(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function min(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.min(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function max(euint32 a, euint8 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function max(euint32 a, uint8 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.max(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function max(uint32 a, euint8 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.max(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function add(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.add(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function add(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.add(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function sub(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.sub(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function sub(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.sub(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function mul(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.mul(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function mul(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.mul(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function and(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function and(euint32 a, uint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function and(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function or(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function or(euint32 a, uint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function or(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function xor(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function xor(euint32 a, uint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function xor(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(
-                    euint32.unwrap(asEuint32(a)),
-                    euint32.unwrap(asEuint32(b))
-                )
             );
     }
 
     function shl(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function shl(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shl(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function shr(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function shr(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.shr(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function eq(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function eq(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function ne(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.ne(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function ne(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function ge(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function ge(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function gt(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function gt(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function le(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function le(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function lt(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function lt(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function min(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.min(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function min(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.min(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function max(euint32 a, euint16 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
             );
     }
 
-    function max(euint32 a, uint16 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.max(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function max(uint32 a, euint16 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.max(euint32.unwrap(asEuint32(b)), uint256(a), true)
-            );
-    }
-
     function add(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.add(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function add(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function add(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
-    }
-
     function sub(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.sub(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function sub(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function sub(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
-    }
-
     function mul(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.mul(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function mul(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function mul(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
-    }
-
     function and(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return euint32.wrap(Impl.and(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function and(euint32 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function and(uint32 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.and(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
     function or(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return euint32.wrap(Impl.or(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function or(euint32 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function or(uint32 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.or(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
     function xor(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    function xor(euint32 a, uint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b)))
-            );
-    }
-
-    function xor(uint32 a, euint32 b) internal view returns (euint32) {
-        return
-            euint32.wrap(
-                Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b))
-            );
-    }
-
     function shl(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function shl(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shl(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
-    }
-
     function shr(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function shr(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function shr(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
-    }
-
     function eq(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.eq(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function eq(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function eq(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.eq(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ne(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.ne(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function ne(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ne(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ne(euint32.unwrap(b), uint256(a), true));
-    }
-
     function ge(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.ge(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function ge(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function ge(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(b), uint256(a), true));
-    }
-
     function gt(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.gt(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function gt(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function gt(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function le(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.le(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function le(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.le(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function le(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.ge(euint32.unwrap(b), uint256(a), true));
-    }
-
     function lt(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.lt(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function lt(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.lt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function lt(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.gt(euint32.unwrap(b), uint256(a), true));
-    }
-
     function min(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.min(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    function min(euint32 a, uint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(a), uint256(b), true));
-    }
-
-    function min(uint32 a, euint32 b) internal view returns (euint32) {
-        return euint32.wrap(Impl.min(euint32.unwrap(b), uint256(a), true));
-    }
-
     function max(euint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return
             euint32.wrap(Impl.max(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
+    function add(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function add(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function sub(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function sub(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function mul(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function mul(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function shl(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function shl(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function shr(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function shr(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function eq(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.eq(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function eq(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.eq(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function ne(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.ne(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function ne(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.ne(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function ge(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.ge(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function ge(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.le(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function gt(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.gt(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function gt(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.lt(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function le(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.le(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function le(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.ge(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function lt(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.lt(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function lt(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.gt(euint32.unwrap(b), uint256(a), true));
+    }
+
+    function min(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.min(euint32.unwrap(a), uint256(b), true));
+    }
+
+    function min(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.min(euint32.unwrap(b), uint256(a), true));
+    }
+
     function max(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
         return euint32.wrap(Impl.max(euint32.unwrap(a), uint256(b), true));
     }
 
     function max(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
     }
 


### PR DESCRIPTION
This PR removes the following incorrect logic of some binary operators:
```solidity
if (a == 0) {
  return b;
} else if (b == 0) {
  return a;
}
```
and introduces initialization logic such that if a `0` handle is passed to any binary operator, the handle is set to point to the trivial encryption of `0`.
This makes it so that FHE operations on uninitialized ciphertexts do not revert, even in the case of ciphertext/plaintext operations.

This PR also introduces a fix for a bug regarding ciphertext/plaintext operations and Solidity's [overload resolution](https://docs.soliditylang.org/en/v0.8.20/contracts.html#overload-resolution-and-argument-matching).
With this fix, ciphertext/plaintext operations are only defined for values of the same bit width, meaning `add(euint32 a, uint32 b)` is defined but `add(euint16 a, uint32 b)` is not.
It is worth noting that the overload resolution process will implicitely upcast the `uint` value such that both
```solidity
add(euint16 a, uint8 b)
add(euint16 a, uint16 b)
```
will work but
```solidity
add(euint16 a, uint32 b)
```
will not.