### PR TITLE
fix(tfhe): add `neg` and `not` overloads

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -488,7 +488,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the negation precompile.
+        // Call the opposite precompile.
         uint256 precompile = Precompiles.Not;
         assembly {
             if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
@@ -932,6 +932,14 @@ to_print="""
 
     function req(euint{i} ciphertext) internal view {{
         Impl.req(euint{i}.unwrap(ciphertext));
+    }}
+
+    function neg(euint{i} ciphertext) internal view {{
+        Impl.neg(euint{i}.unwrap(ciphertext));
+    }}
+
+    function not(euint{i} ciphertext) internal view {{
+        Impl.not(euint{i}.unwrap(ciphertext));
     }}
 """
 

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -672,7 +672,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the negation precompile.
+        // Call the not precompile.
         uint256 precompile = Precompiles.Not;
         assembly {
             if iszero(

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -2436,6 +2436,14 @@ library TFHE {
         Impl.req(euint8.unwrap(ciphertext));
     }
 
+    function neg(euint8 ciphertext) internal view {
+        Impl.neg(euint8.unwrap(ciphertext));
+    }
+
+    function not(euint8 ciphertext) internal view {
+        Impl.not(euint8.unwrap(ciphertext));
+    }
+
     function optReq(euint8 ciphertext) internal view {
         Impl.optReq(euint32.unwrap(asEuint32(ciphertext)));
     }
@@ -2477,6 +2485,14 @@ library TFHE {
         Impl.req(euint16.unwrap(ciphertext));
     }
 
+    function neg(euint16 ciphertext) internal view {
+        Impl.neg(euint16.unwrap(ciphertext));
+    }
+
+    function not(euint16 ciphertext) internal view {
+        Impl.not(euint16.unwrap(ciphertext));
+    }
+
     function optReq(euint16 ciphertext) internal view {
         Impl.optReq(euint32.unwrap(asEuint32(ciphertext)));
     }
@@ -2516,6 +2532,14 @@ library TFHE {
 
     function req(euint32 ciphertext) internal view {
         Impl.req(euint32.unwrap(ciphertext));
+    }
+
+    function neg(euint32 ciphertext) internal view {
+        Impl.neg(euint32.unwrap(ciphertext));
+    }
+
+    function not(euint32 ciphertext) internal view {
+        Impl.not(euint32.unwrap(ciphertext));
     }
 
     function optReq(euint32 ciphertext) internal view {


### PR DESCRIPTION
Add overloads for the `neg` and `not` unary operators.