### PR TITLE
fix(auction): remove use of `euint32.wrap(0)`

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -9,6 +9,9 @@ pragma solidity >=0.8.13 <0.8.20;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
+euint8 constant NIL8 = euint8.wrap(0);
+euint16 constant NIL16 = euint16.wrap(0);
+euint32 constant NIL32 = euint32.wrap(0);
 
 library Common {
     // Values used to communicate types to the runtime.

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -9,9 +9,6 @@ pragma solidity >=0.8.13 <0.8.20;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
-euint8 constant NIL8 = euint8.wrap(0);
-euint16 constant NIL16 = euint16.wrap(0);
-euint32 constant NIL32 = euint32.wrap(0);
 
 library Common {
     // Values used to communicate types to the runtime.
@@ -491,7 +488,7 @@ library Impl {
         bytes32[1] memory output;
         uint256 outputLen = 32;
 
-        // Call the opposite precompile.
+        // Call the not precompile.
         uint256 precompile = Precompiles.Not;
         assembly {
             if iszero(staticcall(gas(), precompile, input, inputLen, output, outputLen)) {
@@ -723,7 +720,10 @@ pragma solidity >=0.8.13 <0.8.20;
 import "./Common.sol";
 import "./Impl.sol";
 
-library TFHE {""")
+library TFHE {
+euint8 constant NIL8 = euint8.wrap(0);
+euint16 constant NIL16 = euint16.wrap(0);
+euint32 constant NIL32 = euint32.wrap(0);""")
         
 to_print_is_initialized =  """
     function isInitialized(euint{i} v) internal pure returns (bool) {{

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -143,7 +143,7 @@ contract BlindAuction is EIP712WithModifier {
         TFHE.req(TFHE.le(highestBid, bids[msg.sender]));
 
         objectClaimed = true;
-        bids[msg.sender] = euint32.wrap(0);
+        delete bids[msg.sender];
         emit Winner(msg.sender);
     }
 
@@ -162,7 +162,7 @@ contract BlindAuction is EIP712WithModifier {
             TFHE.req(TFHE.lt(bidValue, highestBid));
         }
         tokenContract.transfer(msg.sender, bidValue);
-        bids[msg.sender] = euint32.wrap(0);
+        delete bids[msg.sender];
     }
 
     modifier onlyBeforeEnd() {

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -143,7 +143,7 @@ contract BlindAuction is EIP712WithModifier {
         TFHE.req(TFHE.le(highestBid, bids[msg.sender]));
 
         objectClaimed = true;
-        delete bids[msg.sender];
+        bids[msg.sender] = TFHE.NIL32;
         emit Winner(msg.sender);
     }
 
@@ -162,7 +162,7 @@ contract BlindAuction is EIP712WithModifier {
             TFHE.req(TFHE.lt(bidValue, highestBid));
         }
         tokenContract.transfer(msg.sender, bidValue);
-        delete bids[msg.sender];
+        bids[msg.sender] = TFHE.NIL32;
     }
 
     modifier onlyBeforeEnd() {

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -5,6 +5,9 @@ pragma solidity >=0.8.13 <0.8.20;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
+euint8 constant NIL8 = euint8.wrap(0);
+euint16 constant NIL16 = euint16.wrap(0);
+euint32 constant NIL32 = euint32.wrap(0);
 
 library Common {
     // Values used to communicate types to the runtime.

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -5,9 +5,6 @@ pragma solidity >=0.8.13 <0.8.20;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
-euint8 constant NIL8 = euint8.wrap(0);
-euint16 constant NIL16 = euint16.wrap(0);
-euint32 constant NIL32 = euint32.wrap(0);
 
 library Common {
     // Values used to communicate types to the runtime.

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -6,6 +6,10 @@ import "./Common.sol";
 import "./Impl.sol";
 
 library TFHE {
+    euint8 constant NIL8 = euint8.wrap(0);
+    euint16 constant NIL16 = euint16.wrap(0);
+    euint32 constant NIL32 = euint32.wrap(0);
+
     function isInitialized(euint8 v) internal pure returns (bool) {
         return euint8.unwrap(v) != 0;
     }


### PR DESCRIPTION
Introduces `TFHE.NIL` constants to provide initial values for `euint` types.

Note: we cannot use the Solidity `delete` operator to set a variable to its initial value because the `delete` operator is not defined for user-defined value types (e.g., `euint32`). 

This will change in the future when we move to a higher version of the Solidity compiler.

Closes #77.