### PR TITLE
feat(tfhe): add support for `ebool` type

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1003,15 +1003,15 @@ to_print="""
 
 to_print_cast="""
     // Cast an encrypted integer from euint{i} to ebool.
-    function asEbool(euint{i} ciphertext) internal view returns (ebool) {{
-        return ne(ciphertext, 0);
+    function asEbool(euint{i} value) internal view returns (ebool) {{
+        return ne(value, 0);
     }}
 """
 
 to_print_no_cast="""
     // Cast an encrypted integer from euint8 to ebool.
-    function asEbool(euint8 ciphertext) internal view returns (ebool) {{
-        return ne(ciphertext, 0);
+    function asEbool(euint8 value) internal view returns (ebool) {{
+        return ne(value, 0);
     }}
 
     // Convert a serialized `ciphertext` to an encrypted boolean.
@@ -1141,22 +1141,22 @@ f.write("""\
     }
         
     // Converts an `ebool` to an `euint8`.
-    function asEuint8(ebool b) internal view returns (euint8) {{
+    function asEuint8(ebool b) internal pure returns (euint8) {{
         return euint8.wrap(ebool.unwrap(b));
     }}
 
-    // Reencrypt the given `ciphertext` under the given `publicKey`.
-    // Return a serialized euint8 ciphertext.
-    function reencrypt(ebool ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
-        return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+    // Reencrypt the given `value` under the given `publicKey`.
+    // Return a serialized euint8 value.
+    function reencrypt(ebool value, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+        return Impl.reencrypt(ebool.unwrap(value), publicKey);
     }
 
-    // Reencrypt the given `ciphertext` under the given `publicKey`.
-    // Return a serialized euint8 ciphertext.
+    // Reencrypt the given `value` under the given `publicKey`.
+    // Return a serialized euint8 value.
     // If `value` is not initialized, the returned value will contain the `defaultValue` constant.
-    function reencrypt(ebool ciphertext, bytes32 publicKey, bool defaultValue) internal view returns (bytes memory reencrypted) {
-        if (ebool.unwrap(ciphertext) != 0) {
-            return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+    function reencrypt(ebool value, bytes32 publicKey, bool defaultValue) internal view returns (bytes memory reencrypted) {
+        if (ebool.unwrap(value) != 0) {
+            return Impl.reencrypt(ebool.unwrap(value), publicKey);
         } else {
             return Impl.reencrypt(ebool.unwrap(asEbool(defaultValue)), publicKey);
         }

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1139,6 +1139,11 @@ f.write("""\
     function optReq(ebool b) internal view {
         Impl.optReq(ebool.unwrap(b));
     }
+        
+    // Converts an `ebool` to an `euint8`.
+    function asEuint8(ebool b) internal view returns (euint8) {{
+        return euint8.wrap(ebool.unwrap(b));
+    }}
 
     // Reencrypt the given `ciphertext` under the given `publicKey`.
     // Return a serialized euint8 ciphertext.

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -6,12 +6,14 @@ f.write("""\
 
 pragma solidity >=0.8.13 <0.8.20;
 
+type ebool is uint256;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
 
 library Common {
     // Values used to communicate types to the runtime.
+    uint8 internal constant ebool_t = 0;
     uint8 internal constant euint8_t = 0;
     uint8 internal constant euint16_t = 1;
     uint8 internal constant euint32_t = 2;
@@ -750,6 +752,32 @@ to_print_cast_b =  """
     }}
 """
 
+to_print_no_cast_comp =  """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, euint{j} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
+        return ebool.wrap(Impl.cast(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b), false), Common.ebool_t));
+    }}
+"""
+
+to_print_no_cast_comp_8 =  """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, euint{j} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
+        return ebool.wrap(Impl.{f}(euint{i}.unwrap(a), euint{j}.unwrap(b), false));
+    }}
+"""
+
 to_print_no_scalar_no_cast = """
     // Evaluate {f}(a, b) and return the result.
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
@@ -763,6 +791,19 @@ to_print_no_scalar_no_cast = """
     }}
 """
 
+to_print_cast_a_comp =  """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, euint{j} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
+        return ebool.wrap(Impl.cast(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b), false), Common.ebool_t));
+    }}
+"""
+
 to_print_no_scalar_cast_a = """
     // Evaluate {f}(a, b) and return the result.
     function {f}(euint{i} a, euint{j} b) internal view returns (euint{k}) {{
@@ -773,6 +814,19 @@ to_print_no_scalar_cast_a = """
             b = asEuint{j}(0);
         }}
         return euint{k}.wrap(Impl.{f}(euint{j}.unwrap(asEuint{j}(a)), euint{j}.unwrap(b)));
+    }}
+"""
+
+to_print_cast_b_comp =  """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, euint{j} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        if (!isInitialized(b)) {{
+            b = asEuint{j}(0);
+        }}
+        return ebool.wrap(Impl.cast(Impl.{f}(euint{i}.unwrap(a), euint{i}.unwrap(asEuint{i}(b)), false), Common.ebool_t));
     }}
 """
 
@@ -807,9 +861,59 @@ to_print_scalar = """
     }}
 """
 
+to_print_scalar_comp = """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, uint{i} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        return ebool.wrap(Impl.cast(Impl.{f}(euint{i}.unwrap(a), uint256(b), true), Common.ebool_t));
+    }}
+
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(uint{i} a, euint{i} b) internal view returns (ebool) {{
+        if (!isInitialized(b)) {{
+            b = asEuint{i}(0);
+        }}
+        return ebool.wrap(Impl.cast(Impl.{g}(euint{i}.unwrap(b), uint256(a), true), Common.ebool_t));
+    }}
+"""
+
+to_print_scalar_comp_8 = """
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(euint{i} a, uint{i} b) internal view returns (ebool) {{
+        if (!isInitialized(a)) {{
+            a = asEuint{i}(0);
+        }}
+        return ebool.wrap(Impl.{f}(euint{i}.unwrap(a), uint256(b), true));
+    }}
+
+    // Evaluate {f}(a, b) and return the boolean result.
+    function {f}(uint{i} a, euint{i} b) internal view returns (ebool) {{
+        if (!isInitialized(b)) {{
+            b = asEuint{i}(0);
+        }}
+        return ebool.wrap(Impl.{g}(euint{i}.unwrap(b), uint256(a), true));
+    }}
+"""
+
 for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
         if i == j:
+            if i == 8:
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="eq", g="eq"))
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="ne", g="ne"))
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="ge", g="le"))
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="gt", g="lt"))
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="le", g="ge"))
+                f.write(to_print_no_cast_comp_8.format(i=i, j=j, k=i, f="lt", g="gt"))
+            else:
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="eq", g="eq"))
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="ne", g="ne"))
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="ge", g="le"))
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="gt", g="lt"))
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="le", g="ge"))
+                f.write(to_print_no_cast_comp.format(i=i, j=j, k=i, f="lt", g="gt"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="add", g="add"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="sub", g="sub"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="mul", g="mul"))
@@ -818,12 +922,6 @@ for i in (2**p for p in range(3, 6)):
             f.write(to_print_no_scalar_no_cast.format(i=i, j=j, k=i, f="xor"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="shl", g="shl"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="shr", g="shr"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="eq", g="eq"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="ne", g="ne"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="ge", g="le"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="gt", g="lt"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="le", g="ge"))
-            f.write(to_print_no_cast.format(i=i, j=j, k=i, f="lt", g="gt"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="min", g="min"))
             f.write(to_print_no_cast.format(i=i, j=j, k=i, f="max", g="max"))
         elif i < j:
@@ -835,12 +933,12 @@ for i in (2**p for p in range(3, 6)):
             f.write(to_print_no_scalar_cast_a.format(i=i, j=j, k=j, f="xor"))
             f.write(to_print_cast_a.format(i=i, j=j, k=j, f="shl", g="shl"))
             f.write(to_print_cast_a.format(i=i, j=j, k=j, f="shr", g="shr"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="eq", g="eq"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="ne", g="ne"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="ge", g="le"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="gt", g="lt"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="le", g="ge"))
-            f.write(to_print_cast_a.format(i=i, j=j, k=j, f="lt", g="gt"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="eq", g="eq"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="ne", g="ne"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="ge", g="le"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="gt", g="lt"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="le", g="ge"))
+            f.write(to_print_cast_a_comp.format(i=i, j=j, k=j, f="lt", g="gt"))
             f.write(to_print_cast_a.format(i=i, j=j, k=j, f="min", g="min"))
             f.write(to_print_cast_a.format(i=i, j=j, k=j, f="max", g="max"))
         else:
@@ -852,25 +950,34 @@ for i in (2**p for p in range(3, 6)):
             f.write(to_print_no_scalar_cast_b.format(i=i, j=j, k=i, f="xor"))
             f.write(to_print_cast_b.format(i=i, j=j, k=i, f="shl", g="shl"))
             f.write(to_print_cast_b.format(i=i, j=j, k=i, f="shr", g="shr"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="eq", g="eq"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="ne", g="ne"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="ge", g="le"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="gt", g="lt"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="le", g="ge"))
-            f.write(to_print_cast_b.format(i=i, j=j, k=i, f="lt", g="gt"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="eq", g="eq"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="ne", g="ne"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="ge", g="le"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="gt", g="lt"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="le", g="ge"))
+            f.write(to_print_cast_b_comp.format(i=i, j=j, k=i, f="lt", g="gt"))
             f.write(to_print_cast_b.format(i=i, j=j, k=i, f="min", g="min"))
             f.write(to_print_cast_b.format(i=i, j=j, k=i, f="max", g="max"))
+    if i == 8:
+        f.write(to_print_scalar.format(i=i, f="shr", g="shr"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="eq", g="eq"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="ne", g="ne"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="ge", g="le"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="gt", g="lt"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="le", g="ge"))
+        f.write(to_print_scalar_comp_8.format(i=i, f="lt", g="gt"))
+    else:
+        f.write(to_print_scalar.format(i=i, f="shr", g="shr"))
+        f.write(to_print_scalar_comp.format(i=i, f="eq", g="eq"))
+        f.write(to_print_scalar_comp.format(i=i, f="ne", g="ne"))
+        f.write(to_print_scalar_comp.format(i=i, f="ge", g="le"))
+        f.write(to_print_scalar_comp.format(i=i, f="gt", g="lt"))
+        f.write(to_print_scalar_comp.format(i=i, f="le", g="ge"))
+        f.write(to_print_scalar_comp.format(i=i, f="lt", g="gt"))
     f.write(to_print_scalar.format(i=i, f="add", g="add"))
     f.write(to_print_scalar.format(i=i, f="sub", g="sub"))
     f.write(to_print_scalar.format(i=i, f="mul", g="mul"))
     f.write(to_print_scalar.format(i=i, f="shl", g="shl"))
-    f.write(to_print_scalar.format(i=i, f="shr", g="shr"))
-    f.write(to_print_scalar.format(i=i, f="eq", g="eq"))
-    f.write(to_print_scalar.format(i=i, f="ne", g="ne"))
-    f.write(to_print_scalar.format(i=i, f="ge", g="le"))
-    f.write(to_print_scalar.format(i=i, f="gt", g="lt"))
-    f.write(to_print_scalar.format(i=i, f="le", g="ge"))
-    f.write(to_print_scalar.format(i=i, f="lt", g="gt"))
     f.write(to_print_scalar.format(i=i, f="min", g="min"))
     f.write(to_print_scalar.format(i=i, f="max", g="max"))
 
@@ -878,8 +985,8 @@ for i in (2**p for p in range(3, 6)):
 to_print =  """
     // If `control`'s value is 1, the result has the same value as `a`.
     // If `control`'s value is 0, the result has the same value as `b`.
-    function cmux(euint{i} control, euint{i} a, euint{i} b) internal view returns (euint{i}) {{
-        return euint{i}.wrap(Impl.cmux(euint{i}.unwrap(control), euint{i}.unwrap(a), euint{i}.unwrap(b)));
+    function cmux(ebool control, euint{i} a, euint{i} b) internal view returns (euint{i}) {{
+        return euint{i}.wrap(Impl.cmux(ebool.unwrap(control), euint{i}.unwrap(a), euint{i}.unwrap(b)));
     }}
 """
 for i in (2**p for p in range(3, 6)):
@@ -894,10 +1001,42 @@ to_print="""
     }}
 """
 
+to_print_cast="""
+    // Cast an encrypted integer from euint{i} to ebool.
+    function asEbool(euint{i} ciphertext) internal view returns (ebool) {{
+        return ne(ciphertext, 0);
+    }}
+"""
+
+to_print_no_cast="""
+    // Cast an encrypted integer from euint8 to ebool.
+    function asEbool(euint8 ciphertext) internal view returns (ebool) {{
+        return ne(ciphertext, 0);
+    }}
+
+    // Convert a serialized `ciphertext` to an encrypted boolean.
+    function asEbool(bytes memory ciphertext) internal view returns (ebool) {{
+        return asEbool(asEuint8(ciphertext));
+    }}
+
+    // Convert a plaintext boolean to an encrypted boolean.
+    function asEbool(bool value) internal view returns (ebool) {{
+        if (value) {{
+            return asEbool(asEuint8(1));
+        }} else {{
+            return asEbool(asEuint8(0));
+        }}
+    }}
+"""
+
 for i in (2**p for p in range(3, 6)):
     for j in (2**p for p in range(3, 6)):
         if i != j:
             f.write(to_print.format(i=i, j=j))
+    if i != 8:
+        f.write(to_print_cast.format(i=i))
+    else:
+        f.write(to_print_no_cast.format(i=i))
 
 to_print="""
     // Convert a serialized `ciphertext` to an encrypted euint{i} integer.
@@ -990,7 +1129,35 @@ for i in (2**p for p in range(3, 6)):
 
 f.write("\n")
 f.write("""\
-    // Return the network public FHE key.
+    // Require that the encrypted bool `b` is not equal to 0.
+    // Involves decrypting `b`.
+    function req(ebool b) internal view {
+        Impl.req(ebool.unwrap(b));
+    }
+    
+    // Optimistically require that `b` is not equal to 0.
+    function optReq(ebool b) internal view {
+        Impl.optReq(ebool.unwrap(b));
+    }
+
+    // Reencrypt the given `ciphertext` under the given `publicKey`.
+    // Return a serialized euint8 ciphertext.
+    function reencrypt(ebool ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {
+        return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+    }
+
+    // Reencrypt the given `ciphertext` under the given `publicKey`.
+    // Return a serialized euint8 ciphertext.
+    // If `value` is not initialized, the returned value will contain the `defaultValue` constant.
+    function reencrypt(ebool ciphertext, bytes32 publicKey, bool defaultValue) internal view returns (bytes memory reencrypted) {
+        if (ebool.unwrap(ciphertext) != 0) {
+            return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+        } else {
+            return Impl.reencrypt(ebool.unwrap(asEbool(defaultValue)), publicKey);
+        }
+    }
+    
+    // Returns the network public FHE key.
     function fhePubKey() internal view returns (bytes memory) {
         return Impl.fhePubKey();
     }

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -68,13 +68,13 @@ contract BlindAuction is EIP712WithModifier {
         euint32 value = TFHE.asEuint32(encryptedValue);
         euint32 existingBid = bids[msg.sender];
         if (TFHE.isInitialized(existingBid)) {
-            euint32 isHigher = TFHE.lt(existingBid, value);
+            ebool isHigher = TFHE.lt(existingBid, value);
             // Update bid with value
             bids[msg.sender] = TFHE.cmux(isHigher, value, existingBid);
             // Transfer only the difference between existing and value
             euint32 toTransfer = TFHE.sub(value, existingBid);
             // Transfer only if bid is higher
-            euint32 amount = TFHE.mul(isHigher, toTransfer);
+            euint32 amount = TFHE.mul(TFHE.asEuint8(isHigher), toTransfer);
             tokenContract.transferFrom(msg.sender, address(this), amount);
         } else {
             bidCounter++;

--- a/examples/CMUX.sol
+++ b/examples/CMUX.sol
@@ -17,7 +17,7 @@ contract CMUX is EIP712WithModifier {
         bytes calldata ifTrueBytes,
         bytes calldata ifFalseBytes
     ) public {
-        euint8 control = TFHE.asEuint8(controlBytes);
+        ebool control = TFHE.asEbool(controlBytes);
         euint8 ifTrue = TFHE.asEuint8(ifTrueBytes);
         euint8 ifFalse = TFHE.asEuint8(ifFalseBytes);
         result = TFHE.cmux(control, ifTrue, ifFalse);

--- a/lib/Common.sol
+++ b/lib/Common.sol
@@ -2,12 +2,14 @@
 
 pragma solidity >=0.8.13 <0.8.20;
 
+type ebool is uint256;
 type euint8 is uint256;
 type euint16 is uint256;
 type euint32 is uint256;
 
 library Common {
     // Values used to communicate types to the runtime.
+    uint8 internal constant ebool_t = 0;
     uint8 internal constant euint8_t = 0;
     uint8 internal constant euint16_t = 1;
     uint8 internal constant euint32_t = 2;

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -680,8 +680,8 @@ library Impl {
         result = uint256(output[0]);
     }
 
-    // If `control`'s value is 1, the result has the same value as `ifTrue`.
-    // If `control`'s value is 0, the result has the same value as `ifFalse`.
+    // If `control`'s value is `true`, the result has the same value as `ifTrue`.
+    // If `control`'s value is `false`, the result has the same value as `ifFalse`.
     function cmux(
         uint256 control,
         uint256 ifTrue,

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -25,6 +25,72 @@ library TFHE {
         return euint32.unwrap(v) != 0;
     }
 
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ne(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
     // Evaluate add(a, b) and return the result.
     function add(euint8 a, euint8 b) internal view returns (euint8) {
         if (!isInitialized(a)) {
@@ -111,72 +177,6 @@ library TFHE {
             b = asEuint8(0);
         }
         return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ne(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -313,8 +313,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -322,13 +322,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.eq(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -336,13 +343,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.ne(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -350,13 +364,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.ge(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -364,13 +385,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.gt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -378,13 +406,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.le(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint8 a, euint16 b) internal view returns (euint16) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint8 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -392,8 +427,15 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint16.wrap(
-                Impl.lt(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint16.unwrap(asEuint16(a)),
+                        euint16.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -537,8 +579,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -546,13 +588,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -560,13 +609,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -574,13 +630,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -588,13 +651,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -602,13 +672,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint8 a, euint32 b) internal view returns (euint32) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint8 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint8(0);
         }
@@ -616,8 +693,15 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -647,6 +731,118 @@ library TFHE {
             euint32.wrap(
                 Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
             );
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.eq(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.eq(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ne(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ne(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ge(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.le(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.gt(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.lt(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.le(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ge(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint8 a, uint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return ebool.wrap(Impl.lt(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(uint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.gt(euint8.unwrap(b), uint256(a), true));
     }
 
     // Evaluate add(a, b) and return the result.
@@ -711,118 +907,6 @@ library TFHE {
             b = asEuint8(0);
         }
         return euint8.wrap(Impl.shl(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.eq(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.eq(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ne(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ne(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ge(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.le(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.gt(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.lt(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.le(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.ge(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.lt(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.gt(euint8.unwrap(b), uint256(a), true));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -969,8 +1053,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -978,13 +1062,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.eq(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -992,13 +1083,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.ne(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1006,13 +1104,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.ge(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1020,13 +1125,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.gt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1034,13 +1146,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.le(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint16 a, euint8 b) internal view returns (euint16) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint16 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1048,8 +1167,15 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint16.wrap(
-                Impl.lt(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint16.unwrap(a),
+                        euint16.unwrap(asEuint16(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -1078,6 +1204,108 @@ library TFHE {
         return
             euint16.wrap(
                 Impl.max(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false)
+            );
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint16.unwrap(a), euint16.unwrap(b), false),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -1172,78 +1400,6 @@ library TFHE {
         }
         return
             euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.eq(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.ne(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.ge(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.gt(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.le(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return
-            euint16.wrap(Impl.lt(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -1382,8 +1538,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1391,13 +1547,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1405,13 +1568,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1419,13 +1589,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1433,13 +1610,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1447,13 +1631,20 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint16 a, euint32 b) internal view returns (euint32) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint16 a, euint32 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint16(0);
         }
@@ -1461,8 +1652,15 @@ library TFHE {
             b = asEuint32(0);
         }
         return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint32.unwrap(asEuint32(a)),
+                        euint32.unwrap(b),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -1491,6 +1689,190 @@ library TFHE {
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false)
+            );
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint16 a, uint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint16.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(uint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint16.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -1556,118 +1938,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.eq(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.eq(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.ne(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.ne(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.ge(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.le(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.gt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.lt(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.le(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.ge(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.lt(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.gt(euint16.unwrap(b), uint256(a), true));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -1814,8 +2084,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1823,13 +2093,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1837,13 +2114,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1851,13 +2135,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1865,13 +2156,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1879,13 +2177,20 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint32 a, euint8 b) internal view returns (euint32) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint32 a, euint8 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -1893,8 +2198,15 @@ library TFHE {
             b = asEuint8(0);
         }
         return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -2038,8 +2350,8 @@ library TFHE {
             );
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2047,13 +2359,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.eq(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2061,13 +2380,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.ne(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2075,13 +2401,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.ge(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2089,13 +2422,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.gt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate le(a, b) and return the result.
-    function le(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2103,13 +2443,20 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.le(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint32 a, euint16 b) internal view returns (euint32) {
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint32 a, euint16 b) internal view returns (ebool) {
         if (!isInitialized(a)) {
             a = asEuint32(0);
         }
@@ -2117,8 +2464,15 @@ library TFHE {
             b = asEuint16(0);
         }
         return
-            euint32.wrap(
-                Impl.lt(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(
+                        euint32.unwrap(a),
+                        euint32.unwrap(asEuint32(b)),
+                        false
+                    ),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -2147,6 +2501,108 @@ library TFHE {
         return
             euint32.wrap(
                 Impl.max(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false)
+            );
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint32.unwrap(a), euint32.unwrap(b), false),
+                    Common.ebool_t
+                )
             );
     }
 
@@ -2243,78 +2699,6 @@ library TFHE {
             euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.eq(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.ne(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.ge(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.gt(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.le(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return
-            euint32.wrap(Impl.lt(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
     // Evaluate min(a, b) and return the result.
     function min(euint32 a, euint32 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2337,6 +2721,190 @@ library TFHE {
         }
         return
             euint32.wrap(Impl.max(euint32.unwrap(a), euint32.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate eq(a, b) and return the boolean result.
+    function eq(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.eq(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ne(a, b) and return the boolean result.
+    function ne(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ne(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate ge(a, b) and return the boolean result.
+    function ge(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate gt(a, b) and return the boolean result.
+    function gt(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.le(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate le(a, b) and return the boolean result.
+    function le(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.ge(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(euint32 a, uint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.lt(euint32.unwrap(a), uint256(b), true),
+                    Common.ebool_t
+                )
+            );
+    }
+
+    // Evaluate lt(a, b) and return the boolean result.
+    function lt(uint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return
+            ebool.wrap(
+                Impl.cast(
+                    Impl.gt(euint32.unwrap(b), uint256(a), true),
+                    Common.ebool_t
+                )
+            );
     }
 
     // Evaluate add(a, b) and return the result.
@@ -2403,118 +2971,6 @@ library TFHE {
         return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
     }
 
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.eq(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate eq(a, b) and return the result.
-    function eq(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.eq(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.ne(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.ne(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.ge(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.le(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.gt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.lt(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.le(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.ge(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.lt(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.gt(euint32.unwrap(b), uint256(a), true));
-    }
-
     // Evaluate min(a, b) and return the result.
     function min(euint32 a, uint32 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2550,14 +3006,14 @@ library TFHE {
     // If `control`'s value is 1, the result has the same value as `a`.
     // If `control`'s value is 0, the result has the same value as `b`.
     function cmux(
-        euint8 control,
+        ebool control,
         euint8 a,
         euint8 b
     ) internal view returns (euint8) {
         return
             euint8.wrap(
                 Impl.cmux(
-                    euint8.unwrap(control),
+                    ebool.unwrap(control),
                     euint8.unwrap(a),
                     euint8.unwrap(b)
                 )
@@ -2567,14 +3023,14 @@ library TFHE {
     // If `control`'s value is 1, the result has the same value as `a`.
     // If `control`'s value is 0, the result has the same value as `b`.
     function cmux(
-        euint16 control,
+        ebool control,
         euint16 a,
         euint16 b
     ) internal view returns (euint16) {
         return
             euint16.wrap(
                 Impl.cmux(
-                    euint16.unwrap(control),
+                    ebool.unwrap(control),
                     euint16.unwrap(a),
                     euint16.unwrap(b)
                 )
@@ -2584,14 +3040,14 @@ library TFHE {
     // If `control`'s value is 1, the result has the same value as `a`.
     // If `control`'s value is 0, the result has the same value as `b`.
     function cmux(
-        euint32 control,
+        ebool control,
         euint32 a,
         euint32 b
     ) internal view returns (euint32) {
         return
             euint32.wrap(
                 Impl.cmux(
-                    euint32.unwrap(control),
+                    ebool.unwrap(control),
                     euint32.unwrap(a),
                     euint32.unwrap(b)
                 )
@@ -2608,6 +3064,25 @@ library TFHE {
         return euint8.wrap(Impl.cast(euint32.unwrap(value), Common.euint8_t));
     }
 
+    // Cast an encrypted integer from euint8 to ebool.
+    function asEbool(euint8 ciphertext) internal view returns (ebool) {
+        return ne(ciphertext, 0);
+    }
+
+    // Convert a serialized `ciphertext` to an encrypted boolean.
+    function asEbool(bytes memory ciphertext) internal view returns (ebool) {
+        return asEbool(asEuint8(ciphertext));
+    }
+
+    // Convert a plaintext boolean to an encrypted boolean.
+    function asEbool(bool value) internal view returns (ebool) {
+        if (value) {
+            return asEbool(asEuint8(1));
+        } else {
+            return asEbool(asEuint8(0));
+        }
+    }
+
     // Cast an encrypted integer from euint8 to euint16.
     function asEuint16(euint8 value) internal view returns (euint16) {
         return euint16.wrap(Impl.cast(euint8.unwrap(value), Common.euint16_t));
@@ -2618,6 +3093,11 @@ library TFHE {
         return euint16.wrap(Impl.cast(euint32.unwrap(value), Common.euint16_t));
     }
 
+    // Cast an encrypted integer from euint16 to ebool.
+    function asEbool(euint16 ciphertext) internal view returns (ebool) {
+        return ne(ciphertext, 0);
+    }
+
     // Cast an encrypted integer from euint8 to euint32.
     function asEuint32(euint8 value) internal view returns (euint32) {
         return euint32.wrap(Impl.cast(euint8.unwrap(value), Common.euint32_t));
@@ -2626,6 +3106,11 @@ library TFHE {
     // Cast an encrypted integer from euint16 to euint32.
     function asEuint32(euint16 value) internal view returns (euint32) {
         return euint32.wrap(Impl.cast(euint16.unwrap(value), Common.euint32_t));
+    }
+
+    // Cast an encrypted integer from euint32 to ebool.
+    function asEbool(euint32 ciphertext) internal view returns (ebool) {
+        return ne(ciphertext, 0);
     }
 
     // Convert a serialized `ciphertext` to an encrypted euint8 integer.
@@ -2842,7 +3327,43 @@ library TFHE {
         Impl.optReq(euint8.unwrap(asEuint8(value)));
     }
 
-    // Return the network public FHE key.
+    // Require that the encrypted bool `b` is not equal to 0.
+    // Involves decrypting `b`.
+    function req(ebool b) internal view {
+        Impl.req(ebool.unwrap(b));
+    }
+
+    // Optimistically require that `b` is not equal to 0.
+    function optReq(ebool b) internal view {
+        Impl.optReq(ebool.unwrap(b));
+    }
+
+    // Reencrypt the given `ciphertext` under the given `publicKey`.
+    // Return a serialized euint8 ciphertext.
+    function reencrypt(
+        ebool ciphertext,
+        bytes32 publicKey
+    ) internal view returns (bytes memory reencrypted) {
+        return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+    }
+
+    // Reencrypt the given `ciphertext` under the given `publicKey`.
+    // Return a serialized euint8 ciphertext.
+    // If `value` is not initialized, the returned value will contain the `defaultValue` constant.
+    function reencrypt(
+        ebool ciphertext,
+        bytes32 publicKey,
+        bool defaultValue
+    ) internal view returns (bytes memory reencrypted) {
+        if (ebool.unwrap(ciphertext) != 0) {
+            return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+        } else {
+            return
+                Impl.reencrypt(ebool.unwrap(asEbool(defaultValue)), publicKey);
+        }
+    }
+
+    // Returns the network public FHE key.
     function fhePubKey() internal view returns (bytes memory) {
         return Impl.fhePubKey();
     }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -3065,8 +3065,8 @@ library TFHE {
     }
 
     // Cast an encrypted integer from euint8 to ebool.
-    function asEbool(euint8 ciphertext) internal view returns (ebool) {
-        return ne(ciphertext, 0);
+    function asEbool(euint8 value) internal view returns (ebool) {
+        return ne(value, 0);
     }
 
     // Convert a serialized `ciphertext` to an encrypted boolean.
@@ -3094,8 +3094,8 @@ library TFHE {
     }
 
     // Cast an encrypted integer from euint16 to ebool.
-    function asEbool(euint16 ciphertext) internal view returns (ebool) {
-        return ne(ciphertext, 0);
+    function asEbool(euint16 value) internal view returns (ebool) {
+        return ne(value, 0);
     }
 
     // Cast an encrypted integer from euint8 to euint32.
@@ -3109,8 +3109,8 @@ library TFHE {
     }
 
     // Cast an encrypted integer from euint32 to ebool.
-    function asEbool(euint32 ciphertext) internal view returns (ebool) {
-        return ne(ciphertext, 0);
+    function asEbool(euint32 value) internal view returns (ebool) {
+        return ne(value, 0);
     }
 
     // Convert a serialized `ciphertext` to an encrypted euint8 integer.
@@ -3339,31 +3339,31 @@ library TFHE {
     }
 
     // Converts an `ebool` to an `euint8`.
-    function asEuint8(ebool b) internal view returns (euint8) {
+    function asEuint8(ebool b) internal pure returns (euint8) {
         {
             return euint8.wrap(ebool.unwrap(b));
         }
     }
 
-    // Reencrypt the given `ciphertext` under the given `publicKey`.
-    // Return a serialized euint8 ciphertext.
+    // Reencrypt the given `value` under the given `publicKey`.
+    // Return a serialized euint8 value.
     function reencrypt(
-        ebool ciphertext,
+        ebool value,
         bytes32 publicKey
     ) internal view returns (bytes memory reencrypted) {
-        return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+        return Impl.reencrypt(ebool.unwrap(value), publicKey);
     }
 
-    // Reencrypt the given `ciphertext` under the given `publicKey`.
-    // Return a serialized euint8 ciphertext.
+    // Reencrypt the given `value` under the given `publicKey`.
+    // Return a serialized euint8 value.
     // If `value` is not initialized, the returned value will contain the `defaultValue` constant.
     function reencrypt(
-        ebool ciphertext,
+        ebool value,
         bytes32 publicKey,
         bool defaultValue
     ) internal view returns (bytes memory reencrypted) {
-        if (ebool.unwrap(ciphertext) != 0) {
-            return Impl.reencrypt(ebool.unwrap(ciphertext), publicKey);
+        if (ebool.unwrap(value) != 0) {
+            return Impl.reencrypt(ebool.unwrap(value), publicKey);
         } else {
             return
                 Impl.reencrypt(ebool.unwrap(asEbool(defaultValue)), publicKey);

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -3338,6 +3338,13 @@ library TFHE {
         Impl.optReq(ebool.unwrap(b));
     }
 
+    // Converts an `ebool` to an `euint8`.
+    function asEuint8(ebool b) internal view returns (euint8) {
+        {
+            return euint8.wrap(ebool.unwrap(b));
+        }
+    }
+
     // Reencrypt the given `ciphertext` under the given `publicKey`.
     // Return a serialized euint8 ciphertext.
     function reencrypt(

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -3003,8 +3003,8 @@ library TFHE {
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
     }
 
-    // If `control`'s value is 1, the result has the same value as `a`.
-    // If `control`'s value is 0, the result has the same value as `b`.
+    // If `control`'s value is `true`, the result has the same value as `a`.
+    // If `control`'s value is `false, the result has the same value as `b`.
     function cmux(
         ebool control,
         euint8 a,
@@ -3020,8 +3020,8 @@ library TFHE {
             );
     }
 
-    // If `control`'s value is 1, the result has the same value as `a`.
-    // If `control`'s value is 0, the result has the same value as `b`.
+    // If `control`'s value is `true`, the result has the same value as `a`.
+    // If `control`'s value is `false, the result has the same value as `b`.
     function cmux(
         ebool control,
         euint16 a,
@@ -3037,8 +3037,8 @@ library TFHE {
             );
     }
 
-    // If `control`'s value is 1, the result has the same value as `a`.
-    // If `control`'s value is 0, the result has the same value as `b`.
+    // If `control`'s value is `true`, the result has the same value as `a`.
+    // If `control`'s value is `false, the result has the same value as `b`.
     function cmux(
         ebool control,
         euint32 a,


### PR DESCRIPTION
Add support for the `ebool` type. Acts as another wrapper over an `FheUint8`. 
Sort of fixes zama-ai/go-ethereum#127, in the sense that the real `ebool` type is not available yet and this is only syntactic sugar.