### PR TITLE
fix: Add error message for failed TFHE.req() calls [#91]

### DIFF
--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -925,17 +925,21 @@ library Impl {
         result = uint256(output[0]);
     }
 
-    function req(uint256 ciphertext) internal view {
+    function req(uint256 ciphertext) internal view returns (bool, string memory){
         bytes32[1] memory input;
         input[0] = bytes32(ciphertext);
         uint256 inputLen = 32;
 
         // Call the require precompile.
         uint256 precompile = Precompiles.Require;
+        bool result;
         assembly {
-            if iszero(staticcall(gas(), precompile, input, inputLen, 0, 0)) {
-                revert(0, 0)
-            }
+            result := staticcall(gas(), precompile, input, inputLen, 0, 0)
         }
+        
+        if (!result) {
+            return (result,"TFHE.req() failed");
+        }
+        return (result, "TFHE.req() succeded");
     }
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -3155,8 +3155,8 @@ library TFHE {
 
     // Require that the encrypted `value` is not equal to 0.
     // Involves decrypting `value`.
-    function req(euint8 value) internal view {
-        Impl.req(euint8.unwrap(value));
+    function req(euint8 value) internal view returns (bool, string memory){
+        return Impl.req(euint8.unwrap(value));
     }
 
     // Return the negation of `value`.
@@ -3227,9 +3227,10 @@ library TFHE {
 
     // Require that the encrypted `value` is not equal to 0.
     // Involves decrypting `value`.
-    function req(euint16 value) internal view {
-        Impl.req(euint16.unwrap(value));
+    function req(euint16 value) internal view returns (bool, string memory){
+        return Impl.req(euint16.unwrap(value));
     }
+
 
     // Return the negation of `value`.
     function neg(euint16 value) internal view returns (euint16) {
@@ -3299,8 +3300,8 @@ library TFHE {
 
     // Require that the encrypted `value` is not equal to 0.
     // Involves decrypting `value`.
-    function req(euint32 value) internal view {
-        Impl.req(euint32.unwrap(value));
+    function req(euint32 value) internal view returns (bool, string memory){
+        return Impl.req(euint32.unwrap(value));
     }
 
     // Return the negation of `value`.
@@ -3331,8 +3332,8 @@ library TFHE {
 
     // Require that the encrypted bool `b` is not equal to 0.
     // Involves decrypting `b`.
-    function req(ebool b) internal view {
-        Impl.req(ebool.unwrap(b));
+    function req(ebool b) internal view returns (bool, string memory){
+        return Impl.req(ebool.unwrap(b));
     }
 
     // Optimistically require that `b` is not equal to 0.


### PR DESCRIPTION
This basically addresses the need for more informative error handling in our TFHE library. 

## Description:
- Modified `TFHE.req()` in `Impl.sol` to return a tuple `(bool, string)`.
    - `bool` for the status of the TFHE.req() call.
    - `string` for corresponding log messages to imporve debuging experience.
- Adjusted `req()` functions in `TFHE.sol` to handle this new implementation.

## Test Case:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity >=0.8.13 <0.8.20;

import "./lib/TFHE.sol";


contract TestContract {
    
    event ResultLogged(string message);


    // Test values
    euint8 constant TEST_VALUE_PASS = euint8.wrap(123); 
    euint8 constant TEST_VALUE_FAIL = euint8.wrap(0); 


    modifier logsResult(euint8 value) {
        bool _result;
        string memory _message; 

        (_result, _message) = TFHE.req(value);

        if (_result){
            emit ResultLogged(_message);
        } else {
            revert(_message);
        }
        _;
    }


    // This will pass and log TFHE.req() success message
    function testReqPass() public logsResult(TEST_VALUE_PASS){}

    // Once the precompiled contract 69 is setup, This will fail 
    // and revert with the desired error message `TFHE.req() fail`.
    function testReqFail() public logsResult(TEST_VALUE_FAIL){}

}
```

## Impact:
This commit addresses issue #91