### PR TITLE
Add div scalar function

### DIFF
--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -89,6 +89,25 @@ library Impl {
         result = uint256(output[0]);
     }
 
+    function div(uint256 a, uint256 b) internal view returns (uint256 result) {
+        // only scalar is supported now
+        bytes memory input = bytes.concat(bytes32(a), bytes32(b), bytes1(0x01));
+        uint256 inputLen = input.length;
+
+        bytes32[1] memory output;
+        uint256 outputLen = 32;
+
+        // Call the div precompile.
+        uint256 precompile = Precompiles.Divide;
+        assembly {
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, output, outputLen)) {
+                revert(0, 0)
+            }
+        }
+
+        result = uint256(output[0]);
+    }
+
     function and(uint256 a, uint256 b) internal view returns (uint256 result) {
         // scalars not currently supported for bitwise operators
         bytes memory input = bytes.concat(bytes32(a), bytes32(b), bytes1(0x00));

--- a/lib/Precompiles.sol
+++ b/lib/Precompiles.sol
@@ -29,4 +29,5 @@ library Precompiles {
     uint256 public constant Negate = 89;
     uint256 public constant Not = 90;
     uint256 public constant Decrypt = 91;
+    uint256 public constant Divide = 92;
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -761,6 +761,22 @@ library TFHE {
         return euint8.wrap(Impl.max(euint8.unwrap(b), uint256(a), true));
     }
 
+    // Evaluate div(a, b) and return the result.
+    function div(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.div(euint8.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.div(euint8.unwrap(b), uint256(a)));
+    }
+
     // Evaluate add(a, b) and return the result.
     function add(euint16 a, euint8 b) internal view returns (euint16) {
         if (!isInitialized(a)) {
@@ -1497,6 +1513,22 @@ library TFHE {
         return euint16.wrap(Impl.max(euint16.unwrap(b), uint256(a), true));
     }
 
+    // Evaluate div(a, b) and return the result.
+    function div(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.div(euint16.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.div(euint16.unwrap(b), uint256(a)));
+    }
+
     // Evaluate add(a, b) and return the result.
     function add(euint32 a, euint8 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2231,6 +2263,22 @@ library TFHE {
             b = asEuint32(0);
         }
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.div(euint32.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.div(euint32.unwrap(b), uint256(a)));
     }
 
     // If `control`'s value is `true`, the result has the same value as `a`.


### PR DESCRIPTION
Added div call to solidity library.

I added a new template for printing `to_print_scalar_only` which is only for scalar operators, because other templates used `scalar` boolean flag which is not needed here because we only know it will be scalar (I saw other templates `to_print_no_scalar_...` do the same)

@tremblaythibaultl 