### PR TITLE
Remove codegen sorting code

### DIFF
--- a/codegen/common.ts
+++ b/codegen/common.ts
@@ -8,7 +8,6 @@ export type Operator = {
   hasEncrypted: boolean;
   arguments: OperatorArguments;
   returnType: ReturnType;
-  tfheSolOrder: number;
 };
 
 export type Precompile = {
@@ -66,7 +65,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 7,
   },
   {
     name: 'sub',
@@ -75,7 +73,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 8,
   },
   {
     name: 'mul',
@@ -84,7 +81,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 9,
   },
   {
     name: 'div',
@@ -93,7 +89,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: false,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 17,
   },
   {
     name: 'and',
@@ -102,7 +97,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 10,
   },
   {
     name: 'or',
@@ -111,7 +105,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 11,
   },
   {
     name: 'xor',
@@ -120,7 +113,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 12,
   },
   {
     name: 'shl',
@@ -129,7 +121,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 13,
   },
   {
     name: 'shr',
@@ -138,7 +129,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 14,
   },
   {
     name: 'eq',
@@ -147,7 +137,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 1,
   },
   {
     name: 'ne',
@@ -156,7 +145,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 2,
   },
   {
     name: 'ge',
@@ -166,7 +154,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 3,
   },
   {
     name: 'gt',
@@ -176,7 +163,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 4,
   },
   {
     name: 'le',
@@ -186,7 +172,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 5,
   },
   {
     name: 'lt',
@@ -196,7 +181,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Ebool,
-    tfheSolOrder: 6,
   },
   {
     name: 'min',
@@ -205,7 +189,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 15,
   },
   {
     name: 'max',
@@ -214,7 +197,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 16,
   },
   {
     name: 'neg',
@@ -223,7 +205,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Unary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 18,
   },
   {
     name: 'not',
@@ -232,7 +213,6 @@ export const ALL_OPERATORS: Operator[] = [
     hasEncrypted: true,
     arguments: OperatorArguments.Unary,
     returnType: ReturnType.Uint,
-    tfheSolOrder: 19,
   },
 ];
 

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -123,28 +123,11 @@ library TFHE {
 `);
   });
 
-  // TODO: remove sorting tricks once diff is established
-  // this is only done for legacy diffing with original codegen.py
-  const operatorsSorted: Operator[] = Object.assign([], operators);
-  operatorsSorted.sort((a, b) => a.tfheSolOrder - b.tfheSolOrder);
-  const operatorsSorted2: Operator[] = Object.assign([], operators);
-  operatorsSorted2.sort((a, b) => {
-    return opOrderBoost(a) - opOrderBoost(b);
-  });
-  const operatorsSorted3: Operator[] = Object.assign([], operators);
-  operatorsSorted3.sort((a, b) => {
-    return opOrderBoost2(a) - opOrderBoost2(b);
-  });
-
   supportedBits.forEach((lhsBits) => {
     supportedBits.forEach((rhsBits) => {
-      var ops = operatorsSorted;
-      if (rhsBits > lhsBits || rhsBits < lhsBits) {
-        ops = operatorsSorted2;
-      }
-      ops.forEach((operator) => res.push(tfheEncryptedOperator(lhsBits, rhsBits, operator)));
+      operators.forEach((operator) => res.push(tfheEncryptedOperator(lhsBits, rhsBits, operator)));
     });
-    operatorsSorted3.forEach((operator) => res.push(tfheScalarOperator(lhsBits, lhsBits, operator)));
+    operators.forEach((operator) => res.push(tfheScalarOperator(lhsBits, lhsBits, operator)));
   });
 
   // TODO: Decide whether we want to have mixed-inputs for CMUX
@@ -202,26 +185,7 @@ function tfheEncryptedOperator(lhsBits: number, rhsBits: number, operator: Opera
     }
 `);
 
-  // also print scalars if supported
-
   return res.join('');
-}
-
-// TODO: delete after function order no longer important
-function opOrderBoost(op: Operator): number {
-  var num = op.tfheSolOrder;
-  if ((op.name.length == 2 && op.name != 'or') || op.name == 'min' || op.name == 'max') {
-    num += 20;
-  }
-  return num;
-}
-
-function opOrderBoost2(op: Operator): number {
-  var num = op.tfheSolOrder;
-  if (op.name == 'shr') {
-    num -= 20;
-  }
-  return num;
 }
 
 function tfheScalarOperator(lhsBits: number, rhsBits: number, operator: Operator): string {

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -25,72 +25,6 @@ library TFHE {
         return euint32.unwrap(v) != 0;
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.ne(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint8 a, euint8 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return ebool.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
     // Evaluate add(a, b) and return the result.
     function add(euint8 a, euint8 b) internal view returns (euint8) {
         if (!isInitialized(a)) {
@@ -177,6 +111,72 @@ library TFHE {
             b = asEuint8(0);
         }
         return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate eq(a, b) and return the result.
+    function eq(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.eq(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate ne(a, b) and return the result.
+    function ne(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ne(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate ge(a, b) and return the result.
+    function ge(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.ge(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate gt(a, b) and return the result.
+    function gt(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.gt(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate le(a, b) and return the result.
+    function le(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.le(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate lt(a, b) and return the result.
+    function lt(euint8 a, euint8 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return ebool.wrap(Impl.lt(euint8.unwrap(a), euint8.unwrap(b), false));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -553,6 +553,86 @@ library TFHE {
         return euint32.wrap(Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
     }
 
+    // Evaluate add(a, b) and return the result.
+    function add(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.add(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate add(a, b) and return the result.
+    function add(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.add(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.sub(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.sub(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.mul(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.mul(euint8.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.div(euint8.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.div(euint8.unwrap(b), uint256(a)));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint8 a, uint8 b) internal view returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint8 a, euint8 b) internal view returns (euint8) {
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(b), uint256(a), true));
+    }
+
     // Evaluate shr(a, b) and return the result.
     function shr(euint8 a, uint8 b) internal view returns (euint8) {
         if (!isInitialized(a)) {
@@ -665,70 +745,6 @@ library TFHE {
         return ebool.wrap(Impl.gt(euint8.unwrap(b), uint256(a), true));
     }
 
-    // Evaluate add(a, b) and return the result.
-    function add(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.add(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate add(a, b) and return the result.
-    function add(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.add(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.sub(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.sub(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.mul(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.mul(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(b), uint256(a), true));
-    }
-
     // Evaluate min(a, b) and return the result.
     function min(euint8 a, uint8 b) internal view returns (euint8) {
         if (!isInitialized(a)) {
@@ -759,22 +775,6 @@ library TFHE {
             b = asEuint8(0);
         }
         return euint8.wrap(Impl.max(euint8.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(euint8 a, uint8 b) internal view returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.div(euint8.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(uint8 a, euint8 b) internal view returns (euint8) {
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.div(euint8.unwrap(b), uint256(a)));
     }
 
     // Evaluate add(a, b) and return the result.
@@ -953,72 +953,6 @@ library TFHE {
         return euint16.wrap(Impl.max(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.eq(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.ne(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.ge(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.gt(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.le(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint16 a, euint16 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.lt(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
-    }
-
     // Evaluate add(a, b) and return the result.
     function add(euint16 a, euint16 b) internal view returns (euint16) {
         if (!isInitialized(a)) {
@@ -1105,6 +1039,72 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(b), false));
+    }
+
+    // Evaluate eq(a, b) and return the result.
+    function eq(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.eq(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate ne(a, b) and return the result.
+    function ne(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.ne(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate ge(a, b) and return the result.
+    function ge(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.ge(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate gt(a, b) and return the result.
+    function gt(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.gt(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate le(a, b) and return the result.
+    function le(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.le(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate lt(a, b) and return the result.
+    function lt(euint16 a, euint16 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.lt(euint16.unwrap(a), euint16.unwrap(b), false), Common.ebool_t));
     }
 
     // Evaluate min(a, b) and return the result.
@@ -1305,6 +1305,86 @@ library TFHE {
         return euint32.wrap(Impl.max(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
     }
 
+    // Evaluate add(a, b) and return the result.
+    function add(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.add(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate add(a, b) and return the result.
+    function add(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.add(euint16.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.sub(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.sub(euint16.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.mul(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.mul(euint16.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.div(euint16.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.div(euint16.unwrap(b), uint256(a)));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint16 a, uint16 b) internal view returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint16 a, euint16 b) internal view returns (euint16) {
+        if (!isInitialized(b)) {
+            b = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
+    }
+
     // Evaluate shr(a, b) and return the result.
     function shr(euint16 a, uint16 b) internal view returns (euint16) {
         if (!isInitialized(a)) {
@@ -1417,70 +1497,6 @@ library TFHE {
         return ebool.wrap(Impl.cast(Impl.gt(euint16.unwrap(b), uint256(a), true), Common.ebool_t));
     }
 
-    // Evaluate add(a, b) and return the result.
-    function add(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.add(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate add(a, b) and return the result.
-    function add(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.add(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.sub(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.sub(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.mul(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.mul(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(b), uint256(a), true));
-    }
-
     // Evaluate min(a, b) and return the result.
     function min(euint16 a, uint16 b) internal view returns (euint16) {
         if (!isInitialized(a)) {
@@ -1511,22 +1527,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.max(euint16.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(euint16 a, uint16 b) internal view returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.div(euint16.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(uint16 a, euint16 b) internal view returns (euint16) {
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.div(euint16.unwrap(b), uint256(a)));
     }
 
     // Evaluate add(a, b) and return the result.
@@ -1881,72 +1881,6 @@ library TFHE {
         return euint32.wrap(Impl.max(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
     }
 
-    // Evaluate eq(a, b) and return the result.
-    function eq(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.eq(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate ne(a, b) and return the result.
-    function ne(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.ne(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate ge(a, b) and return the result.
-    function ge(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.ge(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate gt(a, b) and return the result.
-    function gt(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.gt(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate le(a, b) and return the result.
-    function le(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.le(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
-    // Evaluate lt(a, b) and return the result.
-    function lt(euint32 a, euint32 b) internal view returns (ebool) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return ebool.wrap(Impl.cast(Impl.lt(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
-    }
-
     // Evaluate add(a, b) and return the result.
     function add(euint32 a, euint32 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2035,6 +1969,72 @@ library TFHE {
         return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(b), false));
     }
 
+    // Evaluate eq(a, b) and return the result.
+    function eq(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.eq(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate ne(a, b) and return the result.
+    function ne(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.ne(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate ge(a, b) and return the result.
+    function ge(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.ge(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate gt(a, b) and return the result.
+    function gt(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.gt(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate le(a, b) and return the result.
+    function le(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.le(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
+    // Evaluate lt(a, b) and return the result.
+    function lt(euint32 a, euint32 b) internal view returns (ebool) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return ebool.wrap(Impl.cast(Impl.lt(euint32.unwrap(a), euint32.unwrap(b), false), Common.ebool_t));
+    }
+
     // Evaluate min(a, b) and return the result.
     function min(euint32 a, euint32 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2055,6 +2055,86 @@ library TFHE {
             b = asEuint32(0);
         }
         return euint32.wrap(Impl.max(euint32.unwrap(a), euint32.unwrap(b), false));
+    }
+
+    // Evaluate add(a, b) and return the result.
+    function add(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate add(a, b) and return the result.
+    function add(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate sub(a, b) and return the result.
+    function sub(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate mul(a, b) and return the result.
+    function mul(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.div(euint32.unwrap(a), uint256(b)));
+    }
+
+    // Evaluate div(a, b) and return the result.
+    function div(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.div(euint32.unwrap(b), uint256(a)));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint32 a, uint32 b) internal view returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint32 a, euint32 b) internal view returns (euint32) {
+        if (!isInitialized(b)) {
+            b = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
     }
 
     // Evaluate shr(a, b) and return the result.
@@ -2169,70 +2249,6 @@ library TFHE {
         return ebool.wrap(Impl.cast(Impl.gt(euint32.unwrap(b), uint256(a), true), Common.ebool_t));
     }
 
-    // Evaluate add(a, b) and return the result.
-    function add(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.add(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate add(a, b) and return the result.
-    function add(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.add(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.sub(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate sub(a, b) and return the result.
-    function sub(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.sub(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.mul(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate mul(a, b) and return the result.
-    function mul(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.mul(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(b), uint256(a), true));
-    }
-
     // Evaluate min(a, b) and return the result.
     function min(euint32 a, uint32 b) internal view returns (euint32) {
         if (!isInitialized(a)) {
@@ -2263,22 +2279,6 @@ library TFHE {
             b = asEuint32(0);
         }
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(euint32 a, uint32 b) internal view returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.div(euint32.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate div(a, b) and return the result.
-    function div(uint32 a, euint32 b) internal view returns (euint32) {
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.div(euint32.unwrap(b), uint256(a)));
     }
 
     // If 'control''s value is 'true', the result has the same value as 'a'.


### PR DESCRIPTION
This just removes ordering code which kept codegen in the same as legacy `codegen.py`, diff for TFHE.sol is large but semantic meaning doesn't change.

@immortal-tofu @tremblaythibaultl 