### PR TITLE
Fix input type for the fheRand precompile

### DIFF
--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -725,7 +725,7 @@ function implCustomMethods(): string {
     }
 
     function rand(uint8 randType) internal view returns(uint256 result) {
-      bytes32[1] memory input;
+      bytes1[1] memory input;
       input[0] = bytes1(randType);
       uint256 inputLen = 1;
 

--- a/examples/Governor/GovernorZama.sol
+++ b/examples/Governor/GovernorZama.sol
@@ -260,8 +260,8 @@ contract GovernorZama {
     }
 
     function cancel(uint proposalId) public {
-        ProposalState state = state(proposalId);
-        require(state != ProposalState.Executed, "GovernorAlpha::cancel: cannot cancel executed proposal");
+        ProposalState proposalState = state(proposalId);
+        require(proposalState != ProposalState.Executed, "GovernorAlpha::cancel: cannot cancel executed proposal");
 
         Proposal storage proposal = proposals[proposalId];
 

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -600,7 +600,7 @@ library Impl {
     }
 
     function rand(uint8 randType) internal view returns (uint256 result) {
-        bytes32[1] memory input;
+        bytes1[1] memory input;
         input[0] = bytes1(randType);
         uint256 inputLen = 1;
 


### PR DESCRIPTION
Change from bytes32[1] to bytes1[1] as we only send 1 byte for the int type.

Fix compiler warning in GovernorZama.sol.