### PR TITLE
fix() force 0.8.19 version for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pnpm add fhevm
 ```solidity
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "fhevm/lib/TFHE.sol";
 

--- a/abstracts/EIP712WithModifier.sol
+++ b/abstracts/EIP712WithModifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -50,7 +50,7 @@ export function implSol(operators: Operator[]): string {
   res.push(`
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 ${fheLibInterface}
 
@@ -143,7 +143,7 @@ export function tfheSol(operators: Operator[], supportedBits: number[]): [string
 
   res.push(`// SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 ${commonSolLib()}
 
@@ -516,7 +516,7 @@ export function precompiles(precompiles: Precompile[]): string {
 
   res.push(`// SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 library Precompiles {
 `);

--- a/codegen/testgen.ts
+++ b/codegen/testgen.ts
@@ -188,7 +188,7 @@ export function generateSmartContract(os: OverloadShard): string {
 
   res.push(`
         // SPDX-License-Identifier: BSD-3-Clause-Clear
-        pragma solidity >=0.8.13 <0.8.20;
+        pragma solidity ^0.8.19;
 
         import "../../lib/TFHE.sol";
         contract TFHETestSuite${os.shardNumber} {

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../lib/TFHE.sol";
 

--- a/examples/CMUX.sol
+++ b/examples/CMUX.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../abstracts/EIP712WithModifier.sol";
 import "../lib/TFHE.sol";

--- a/examples/EIP712.sol
+++ b/examples/EIP712.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../abstracts/EIP712WithModifier.sol";
 

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../abstracts/EIP712WithModifier.sol";
 

--- a/examples/Governor/Comp.sol
+++ b/examples/Governor/Comp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity >=0.8.19 <0.9.0;
+pragma solidity ^0.8.19;
 
 import "../../abstracts/EIP712WithModifier.sol";
 

--- a/examples/OptimisticRequire.sol
+++ b/examples/OptimisticRequire.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../lib/TFHE.sol";
 

--- a/examples/Rand.sol
+++ b/examples/Rand.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../lib/TFHE.sol";
 

--- a/examples/tests/TFHEManualTestSuite.sol
+++ b/examples/tests/TFHEManualTestSuite.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../../lib/TFHE.sol";
 

--- a/examples/tests/TFHETestSuite1.sol
+++ b/examples/tests/TFHETestSuite1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../../lib/TFHE.sol";
 

--- a/examples/tests/TFHETestSuite2.sol
+++ b/examples/tests/TFHETestSuite2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../../lib/TFHE.sol";
 

--- a/examples/tests/TFHETestSuite3.sol
+++ b/examples/tests/TFHETestSuite3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 import "../../lib/TFHE.sol";
 

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 interface FhevmLib {
     function fheAdd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-pragma solidity >=0.8.13 <0.8.20;
+pragma solidity ^0.8.19;
 
 type ebool is uint256;
 type euint8 is uint256;


### PR DESCRIPTION
Without this fix, if a contract is written with a solidity version below, it raises an error because overload is not supported