### PR TITLE
Fix optimistic requires

### DIFF
--- a/examples/tests/TFHEManualTestSuite.sol
+++ b/examples/tests/TFHEManualTestSuite.sol
@@ -22,4 +22,8 @@ contract TFHEManualTestSuite {
     function test_ebool_to_euint32_cast(bool input) public view returns (uint32) {
         return TFHE.decrypt(TFHE.asEuint32(TFHE.asEbool(input)));
     }
+
+    function test_opt_req(bool input) public view {
+        TFHE.optReq(TFHE.asEbool(input));
+    }
 }

--- a/examples/tests/TFHEManualTestSuite.sol
+++ b/examples/tests/TFHEManualTestSuite.sol
@@ -26,4 +26,11 @@ contract TFHEManualTestSuite {
     function test_opt_req(bool input) public view {
         TFHE.optReq(TFHE.asEbool(input));
     }
+
+    uint32 counter = 0;
+
+    function test_opt_req_stateful(bool input) public {
+        TFHE.optReq(TFHE.asEbool(input));
+        counter += 1;
+    }
 }

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -41,8 +41,6 @@ interface FhevmLib {
 
     function fheNot(uint256 ct) external pure returns (uint256 result);
 
-    function optimisticRequire(uint256 ct) external view;
-
     function reencrypt(uint256 ct, uint256 publicKey) external view returns (bytes memory);
 
     function fhePubKey(bytes1 fromLib) external view returns (bytes memory result);
@@ -235,8 +233,19 @@ library Impl {
         result = FhevmLib(address(EXT_TFHE_LIBRARY)).fheAdd(mulOutput, ifFalse, bytes1(0x00));
     }
 
+    // We do assembly here because ordinary call will emit extcodesize check which is zero for our precompiles
+    // and revert the transaction because we don't return any data for this precompile method
     function optReq(uint256 ciphertext) internal view {
-        FhevmLib(address(EXT_TFHE_LIBRARY)).optimisticRequire(ciphertext);
+        bytes memory input = abi.encodeWithSignature("optimisticRequire(uint256)", ciphertext);
+        uint256 inputLen = input.length;
+
+        // Call the optimistic require precompile.
+        address precompile = EXT_TFHE_LIBRARY;
+        assembly {
+            if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, 0, 0)) {
+                revert(0, 0)
+            }
+        }
     }
 
     function reencrypt(uint256 ciphertext, bytes32 publicKey) internal view returns (bytes memory reencrypted) {

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -239,7 +239,7 @@ library Impl {
         bytes memory input = abi.encodeWithSignature("optimisticRequire(uint256)", ciphertext);
         uint256 inputLen = input.length;
 
-        // Call the optimistic require precompile.
+        // Call the optimistic require method in precompile.
         address precompile = EXT_TFHE_LIBRARY;
         assembly {
             if iszero(staticcall(gas(), precompile, add(input, 32), inputLen, 0, 0)) {

--- a/test/tfheOperations/manual.ts
+++ b/test/tfheOperations/manual.ts
@@ -79,4 +79,16 @@ describe('TFHE manual operations', function () {
       expect(e.message).to.contain('execution reverted');
     }
   });
+
+  it('stateful optimistic require with true succeeds', async function () {
+    const res = await this.contract.test_opt_req_stateful(true);
+    const receipt = await res.wait();
+    expect(receipt.status).to.equal(1);
+  });
+
+  it('stateful optimistic require with false fails', async function () {
+    const res = await this.contract.test_opt_req_stateful(false);
+    const receipt = await res.wait();
+    expect(receipt.status).to.not.equal(1);
+  });
 });

--- a/test/tfheOperations/manual.ts
+++ b/test/tfheOperations/manual.ts
@@ -1,3 +1,4 @@
+import { fail } from 'assert';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
@@ -64,5 +65,18 @@ describe('TFHE manual operations', function () {
   it('ebool to euint32 casting works with false', async function () {
     const res = await this.contract.test_ebool_to_euint32_cast(false);
     expect(res).to.equal(0);
+  });
+
+  it('optimistic require with true succeeds', async function () {
+    await this.contract.test_opt_req(true);
+  });
+
+  it('optimistic require with false fails', async function () {
+    try {
+      await this.contract.test_opt_req(false);
+      fail('This should fail');
+    } catch (e: any) {
+      expect(e.message).to.contain('execution reverted');
+    }
   });
 });

--- a/test/tfheOperations/tfheOperations.ts
+++ b/test/tfheOperations/tfheOperations.ts
@@ -5,11 +5,11 @@ import type { TFHETestSuite1 } from '../../types/contracts/tests/TFHETestSuite1'
 import type { TFHETestSuite2 } from '../../types/contracts/tests/TFHETestSuite2';
 import type { TFHETestSuite3 } from '../../types/contracts/tests/TFHETestSuite3';
 import { createInstances } from '../instance';
-import { getSigners, initSigners } from '../signers';
+import { getSigners } from '../signers';
 
 async function deployTfheTestFixture1(): Promise<TFHETestSuite1> {
-  const signers = await getSigners();
-  const admin = signers.alice;
+  const signers = await ethers.getSigners();
+  const admin = signers[0];
 
   const contractFactory = await ethers.getContractFactory('TFHETestSuite1');
   const contract = await contractFactory.connect(admin).deploy();
@@ -19,8 +19,8 @@ async function deployTfheTestFixture1(): Promise<TFHETestSuite1> {
 }
 
 async function deployTfheTestFixture2(): Promise<TFHETestSuite2> {
-  const signers = await getSigners();
-  const admin = signers.alice;
+  const signers = await ethers.getSigners();
+  const admin = signers[0];
 
   const contractFactory = await ethers.getContractFactory('TFHETestSuite2');
   const contract = await contractFactory.connect(admin).deploy();
@@ -30,8 +30,8 @@ async function deployTfheTestFixture2(): Promise<TFHETestSuite2> {
 }
 
 async function deployTfheTestFixture3(): Promise<TFHETestSuite3> {
-  const signers = await getSigners();
-  const admin = signers.alice;
+  const signers = await ethers.getSigners();
+  const admin = signers[0];
 
   const contractFactory = await ethers.getContractFactory('TFHETestSuite3');
   const contract = await contractFactory.connect(admin).deploy();
@@ -42,7 +42,6 @@ async function deployTfheTestFixture3(): Promise<TFHETestSuite3> {
 
 describe('TFHE operations', function () {
   before(async function () {
-    await initSigners(1);
     this.signers = await getSigners();
 
     const contract1 = await deployTfheTestFixture1();


### PR DESCRIPTION
Call optimistic require precompile using assembly instead of fhelib interface.

This is needed because if we call through interface solidity compiler generates `EXTCODESIZE` and checks that our precompile code size is not zero, which it is, even though it is code.

Here is where code is generated in solidity compile for the check that makes our transactions to revert https://github.com/ethereum/solidity/blob/b54e7207739e48c5a7712a4683a9591a6c64b7cd/libsolidity/codegen/ExpressionCompiler.cpp#L2784

@dartdart26 @tremblaythibaultl @immortal-tofu