### PR TITLE
Get FHE public key from the fhEVM precompile

### DIFF
--- a/test/instance.ts
+++ b/test/instance.ts
@@ -21,9 +21,13 @@ export const createInstances = async (
     chainId = +network.chainId.toString(); // Need to be a number
 
     // Get blockchain public key
-    publicKey = await provider.call({
-      to: '0x0000000000000000000000000000000000000044',
+    const ret = await provider.call({
+      to: '0x000000000000000000000000000000000000005d',
+      // first four bytes of keccak256('fhePubKey(bytes1)') + 1 byte for library
+      data: '0xd9d47bb001',
     });
+    const decoded = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], ret);
+    publicKey = decoded[0];
   }
 
   // Create instance


### PR DESCRIPTION
Instead of calling the public key precompile directly, call it from the global fhEVM precompile. Doing so will allow us to remove separate precompiles in the near future.

Credit to @david-zama for suggesting that.