### PR TITLE
Fix network1 tests waiting for new block

### DIFF
--- a/examples/Counter.sol
+++ b/examples/Counter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.19;
+
+// dummy contract for dummy transactions just to advance blocks
+contract Counter {
+    uint32 value;
+
+    function increment() public {
+        value += 1;
+    }
+
+    function currentValue() public view returns (uint32) {
+        return value;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "fhevm:start": "docker run -i -p 8545:8545 --rm --name fhevm ghcr.io/zama-ai/evmos-dev-node:v0.1.10",
     "fhevm:stop": "docker rm -f fhevm",
     "fhevm:restart": "fhevm:stop && fhevm:start",
-    "fhevm:faucet": "npm run fhevm:faucet:alice && sleep 5 && npm run fhevm:faucet:bob && sleep 5 && npm run fhevm:faucet:carol && sleep 5 && npm run fhevm:faucet:dave",
+    "fhevm:faucet": "npm run fhevm:faucet:alice && sleep 5 && npm run fhevm:faucet:bob && sleep 5 && npm run fhevm:faucet:carol && sleep 5 && npm run fhevm:faucet:dave && sleep 5 && npm run fhevm:faucet:eve",
     "fhevm:faucet:alice": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressAlice)",
     "fhevm:faucet:bob": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressBob)",
     "fhevm:faucet:carol": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressCarol)",
-    "fhevm:faucet:dave": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressDave)"
+    "fhevm:faucet:dave": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressDave)",
+    "fhevm:faucet:eve": "docker exec -i fhevm faucet $(npx hardhat task:getEthereumAddressEve)"
   },
   "repository": {
     "type": "git",

--- a/tasks/getEthereumAddress.ts
+++ b/tasks/getEthereumAddress.ts
@@ -23,7 +23,7 @@ task(
   getEthereumAddress(0),
 );
 
-const accounts = ['Alice', 'Bob', 'Carol', 'Dave'];
+const accounts = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve'];
 
 accounts.forEach((name, index) => {
   task(

--- a/test/signers.ts
+++ b/test/signers.ts
@@ -13,11 +13,12 @@ export interface Signers {
   bob: HDNodeWallet | HardhatEthersSigner;
   carol: HDNodeWallet | HardhatEthersSigner;
   dave: HDNodeWallet | HardhatEthersSigner;
+  eve: HDNodeWallet | HardhatEthersSigner;
 }
 
 let signers: Signers;
 
-const keys: (keyof Signers)[] = ['alice', 'bob', 'carol', 'dave'];
+const keys: (keyof Signers)[] = ['alice', 'bob', 'carol', 'dave', 'eve'];
 
 const getCoin = async (address: string) => {
   const containerName = process.env['TEST_CONTAINER_NAME'] || 'fhevm';
@@ -42,6 +43,7 @@ export const initSigners = async (quantity: number): Promise<void> => {
         bob: ethers.Wallet.createRandom().connect(ethers.provider),
         carol: ethers.Wallet.createRandom().connect(ethers.provider),
         dave: ethers.Wallet.createRandom().connect(ethers.provider),
+        eve: ethers.Wallet.createRandom().connect(ethers.provider),
       };
     } else if (!process.env.HARDHAT_PARALLEL) {
       const eSigners = await ethers.getSigners();
@@ -50,6 +52,7 @@ export const initSigners = async (quantity: number): Promise<void> => {
         bob: eSigners[1],
         carol: eSigners[2],
         dave: eSigners[3],
+        eve: eSigners[4],
       };
     } else {
       throw new Error("Can't run parallel mode if network is not 'local'");

--- a/test/types.ts
+++ b/test/types.ts
@@ -23,4 +23,5 @@ export interface FhevmInstances {
   bob: FhevmInstance;
   carol: FhevmInstance;
   dave: FhevmInstance;
+  eve: FhevmInstance;
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,9 @@
 import { ContractMethodArgs, Typed } from 'ethers';
 import { ethers } from 'hardhat';
 
+import type { Counter } from '../types';
 import { TypedContractMethod } from '../types/common';
+import { getSigners } from './signers';
 
 export const waitForBlock = (blockNumber: bigint) => {
   return new Promise((resolve, reject) => {
@@ -43,3 +45,23 @@ export const createTransaction = async <A extends [...{ [I in keyof A]-?: A[I] |
   ];
   return method(...updatedParams);
 };
+
+export const produceDummyTransactions = async (blockCount: number) => {
+  const contract = await deployCounterContract();
+  let counter = blockCount;
+  while (counter > 0) {
+    counter--;
+    const tx = await contract.increment();
+    const _ = await tx.wait();
+  }
+};
+
+async function deployCounterContract(): Promise<Counter> {
+  const signers = await getSigners();
+
+  const contractFactory = await ethers.getContractFactory('Counter');
+  const contract = await contractFactory.connect(signers.eve).deploy();
+  await contract.waitForDeployment();
+
+  return contract;
+}


### PR DESCRIPTION
Adds utility function to generate transactions so blocks would be always produced by network1 (there blocks are not produced unless transactions are added)

Also adds new eve signer account (if the same ones reused the utility function to generate transactions don't work)

@immortal-tofu @dartdart26 