### PR TITLE
fix() stateful optimistic require false test

### DIFF
--- a/test/tfheOperations/manual.ts
+++ b/test/tfheOperations/manual.ts
@@ -90,12 +90,8 @@ describe('TFHE manual operations', function () {
 
     it('stateful optimistic require with false fails', async function () {
       const res = await this.contract.test_opt_req_stateful(false);
-      try {
-        const _ = await res.wait();
-        fail('This should fail');
-      } catch (e: any) {
-        expect(e.toString()).to.contain('transaction execution reverted');
-      }
+      const receipt = await res.wait();
+      expect(receipt.status).to.not.equal(1);
     });
   }
 });


### PR DESCRIPTION
Instead of expecting an exception, expect that the receipt's status will be different than 1, i.e. failing.