### PR TITLE
fix typo in the document, solidity, functions

### DIFF
--- a/docs/solidity/functions.md
+++ b/docs/solidity/functions.md
@@ -127,7 +127,7 @@ The result of comparison operations is an encrypted boolean (`ebool`). In the ba
 function eq(euint32 a, euint16 b) internal view returns (ebool)
 
 // actually returns `lt(b, a)`
-function gt(uint32 a, euint16 b) internal view returns (ebool)
+function lt(uint32 a, euint16 b) internal view returns (ebool)
 
 // actually returns `gt(a, b)`
 function gt(euint16 a, uint32 b) internal view returns (ebool)


### PR DESCRIPTION
Hello, I found one typo in the Comparison operation part https://docs.zama.ai/fhevm/writing-contracts/functions