### PR TITLE
fix(faucet): add a grep to ignore info statements

### DIFF
--- a/test/signers.ts
+++ b/test/signers.ts
@@ -22,7 +22,7 @@ const keys: (keyof Signers)[] = ['alice', 'bob', 'carol', 'dave', 'eve'];
 
 const getCoin = async (address: string) => {
   const containerName = process.env['TEST_CONTAINER_NAME'] || 'fhevm';
-  const response = await exec(`docker exec -i ${containerName} faucet ${address}`);
+  const response = await exec(`docker exec -i ${containerName} faucet ${address} | grep height`);
   const res = JSON.parse(response.stdout);
   if (res.raw_log.match('account sequence mismatch')) await getCoin(address);
 };


### PR DESCRIPTION
For the new stack some info statements can appear when calling faucet which call ethermintd keys list output=json

INFO: global keys loaded from: /root/.ethermintd/zama/keys/network-fhe-keys INFO: global keys are initialized automatically using FHEVM_GO_KEYS_DIR env variable {"height":"0","txhash":"A..."}