### PR TITLE
feat: add upper bound for encrypted random integers

### DIFF
--- a/examples/Rand.sol
+++ b/examples/Rand.sol
@@ -16,12 +16,24 @@ contract Rand {
         value8 = TFHE.randEuint8();
     }
 
+    function generate8UpperBound(uint8 upperBound) public {
+        value8 = TFHE.randEuint8(upperBound);
+    }
+
     function generate16() public {
         value16 = TFHE.randEuint16();
     }
 
+    function generate16UpperBound(uint16 upperBound) public {
+        value16 = TFHE.randEuint16(upperBound);
+    }
+
     function generate32() public {
         value32 = TFHE.randEuint32();
+    }
+
+    function generate32UpperBound(uint32 upperBound) public {
+        value32 = TFHE.randEuint32(upperBound);
     }
 
     function decrypt8() public view returns (uint8) {
@@ -54,12 +66,27 @@ contract Rand {
     }
 
     // Must fail.
+    function generate8UpperBoundInView(uint8 upperBound) public view {
+        TFHE.randEuint8(upperBound);
+    }
+
+    // Must fail.
     function generate16InView() public view {
         TFHE.randEuint16();
     }
 
     // Must fail.
+    function generate16UpperBoundInView(uint16 upperBound) public view {
+        TFHE.randEuint16(upperBound);
+    }
+
+    // Must fail.
     function generate32InView() public view {
         TFHE.randEuint32();
+    }
+
+    // Must fail.
+    function generate32UpperBoundInView(uint32 upperBound) public view {
+        TFHE.randEuint32(upperBound);
     }
 }

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.20;
 
+import "./TFHE.sol";
+
 interface FhevmLib {
     function fheAdd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
 
@@ -55,9 +57,11 @@ interface FhevmLib {
 
     function decrypt(uint256 ct) external view returns (uint256 result);
 
-    function fheRand(bytes1 inp) external view returns (uint256 result);
-
     function fheIfThenElse(uint256 control, uint256 ifTrue, uint256 ifFalse) external pure returns (uint256 result);
+
+    function fheRand(bytes1 randType) external view returns (uint256 result);
+
+    function fheRandBounded(uint256 upperBound, bytes1 randType) external view returns (uint256 result);
 }
 
 address constant EXT_TFHE_LIBRARY = address(0x000000000000000000000000000000000000005d);
@@ -282,5 +286,9 @@ library Impl {
 
     function rand(uint8 randType) internal view returns (uint256 result) {
         result = FhevmLib(address(EXT_TFHE_LIBRARY)).fheRand(bytes1(randType));
+    }
+
+    function randBounded(uint256 upperBound, uint8 randType) internal view returns (uint256 result) {
+        result = FhevmLib(address(EXT_TFHE_LIBRARY)).fheRandBounded(upperBound, bytes1(randType));
     }
 }

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -2426,16 +2426,37 @@ library TFHE {
         return euint8.wrap(Impl.rand(Common.euint8_t));
     }
 
+    // Generates a random encrypted 8-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint8(uint8 upperBound) internal view returns (euint8) {
+        return euint8.wrap(Impl.randBounded(upperBound, Common.euint8_t));
+    }
+
     // Generates a random encrypted 16-bit unsigned integer.
     // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
     function randEuint16() internal view returns (euint16) {
         return euint16.wrap(Impl.rand(Common.euint16_t));
     }
 
+    // Generates a random encrypted 16-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint16(uint16 upperBound) internal view returns (euint16) {
+        return euint16.wrap(Impl.randBounded(upperBound, Common.euint16_t));
+    }
+
     // Generates a random encrypted 32-bit unsigned integer.
     // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
     function randEuint32() internal view returns (euint32) {
         return euint32.wrap(Impl.rand(Common.euint32_t));
+    }
+
+    // Generates a random encrypted 32-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint32(uint32 upperBound) internal view returns (euint32) {
+        return euint32.wrap(Impl.randBounded(upperBound, Common.euint32_t));
     }
 }
 

--- a/mocks/Impl.sol
+++ b/mocks/Impl.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.20;
 
+import "./TFHE.sol";
+
 library Impl {
     function add(uint256 lhs, uint256 rhs, bool scalar) internal pure returns (uint256 result) {
         unchecked {
@@ -157,6 +159,22 @@ library Impl {
     }
 
     function rand(uint8 randType) internal view returns (uint256 result) {
-        result = uint256(keccak256(abi.encodePacked(block.number, gasleft(), msg.sender))); // assuming no duplicated tx by same sender in a single block
+        uint256 randomness = uint256(keccak256(abi.encodePacked(block.number, gasleft(), msg.sender))); // assuming no duplicated tx by same sender in a single block
+        if (randType == Common.euint8_t) {
+            result = uint8(randomness);
+        } else if (randType == Common.euint16_t) {
+            result = uint16(randomness);
+        } else if (randType == Common.euint32_t) {
+            result = uint32(randomness);
+        } else {
+            revert("rand() mock invalid type");
+        }
+    }
+
+    function randBounded(uint256 upperBound, uint8 randType) internal view returns (uint256 result) {
+        // Here, we assume upperBound is a power of 2. Therefore, using modulo is secure.
+        // If not a power of 2, we might have to do something else (though might not matter
+        // much as this is a mock).
+        result = rand(randType) % upperBound;
     }
 }

--- a/mocks/TFHE.sol
+++ b/mocks/TFHE.sol
@@ -2426,16 +2426,37 @@ library TFHE {
         return euint8.wrap(Impl.rand(Common.euint8_t));
     }
 
+    // Generates a random encrypted 8-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint8(uint8 upperBound) internal view returns (euint8) {
+        return euint8.wrap(Impl.randBounded(upperBound, Common.euint8_t));
+    }
+
     // Generates a random encrypted 16-bit unsigned integer.
     // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
     function randEuint16() internal view returns (euint16) {
         return euint16.wrap(Impl.rand(Common.euint16_t));
     }
 
+    // Generates a random encrypted 16-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint16(uint16 upperBound) internal view returns (euint16) {
+        return euint16.wrap(Impl.randBounded(upperBound, Common.euint16_t));
+    }
+
     // Generates a random encrypted 32-bit unsigned integer.
     // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
     function randEuint32() internal view returns (euint32) {
         return euint32.wrap(Impl.rand(Common.euint32_t));
+    }
+
+    // Generates a random encrypted 32-bit unsigned integer in the [0, upperBound) range.
+    // The upperBound must be a power of 2.
+    // Important: The random integer is generated in the plain! An FHE-based version is coming soon.
+    function randEuint32(uint32 upperBound) internal view returns (euint32) {
+        return euint32.wrap(Impl.randBounded(upperBound, Common.euint32_t));
     }
 }
 

--- a/test/rand/Rand.ts
+++ b/test/rand/Rand.ts
@@ -32,6 +32,20 @@ describe('Rand', function () {
     expect(unique.size).to.be.greaterThanOrEqual(2);
   });
 
+  it('8 bits generate with upper bound and decrypt', async function () {
+    const values: bigint[] = [];
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate8UpperBound(128);
+      await txn.wait();
+      const value = await this.rand.decrypt8();
+      expect(value).to.be.lessThanOrEqual(127);
+      values.push(value);
+    }
+    // Expect at least two different generated values.
+    const unique = new Set(values);
+    expect(unique.size).to.be.greaterThanOrEqual(2);
+  });
+
   it('16 bits generate and decrypt', async function () {
     const values: bigint[] = [];
     let has16bit: boolean = false;
@@ -47,6 +61,20 @@ describe('Rand', function () {
     }
     // Make sure we actually generate 16 bit integers.
     expect(has16bit).to.be.true;
+    // Expect at least two different generated values.
+    const unique = new Set(values);
+    expect(unique.size).to.be.greaterThanOrEqual(2);
+  });
+
+  it('16 bits generate with upper bound and decrypt', async function () {
+    const values: bigint[] = [];
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate16UpperBound(8192);
+      await txn.wait();
+      const value = await this.rand.decrypt16();
+      expect(value).to.be.lessThanOrEqual(8191);
+      values.push(value);
+    }
     // Expect at least two different generated values.
     const unique = new Set(values);
     expect(unique.size).to.be.greaterThanOrEqual(2);
@@ -72,8 +100,29 @@ describe('Rand', function () {
     expect(unique.size).to.be.greaterThanOrEqual(2);
   });
 
+  it('32 bits generate with upper bound and decrypt', async function () {
+    const values: bigint[] = [];
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate32UpperBound(262144);
+      await txn.wait();
+      const value = await this.rand.decrypt32();
+      expect(value).to.be.lessThanOrEqual(262141);
+      values.push(value);
+    }
+    // Expect at least two different generated values.
+    const unique = new Set(values);
+    expect(unique.size).to.be.greaterThanOrEqual(2);
+  });
+
   it('8 bits generate, decrypt and store', async function () {
     const txnGen = await this.rand.generate8();
+    await txnGen.wait();
+    const txnDecAndStore = await this.rand.decryptAndStore8();
+    await expect(txnDecAndStore.wait()).to.not.be.rejected;
+  });
+
+  it('8 bits generate with upper bound, decrypt and store', async function () {
+    const txnGen = await this.rand.generate8UpperBound(64);
     await txnGen.wait();
     const txnDecAndStore = await this.rand.decryptAndStore8();
     await expect(txnDecAndStore.wait()).to.not.be.rejected;
@@ -86,8 +135,22 @@ describe('Rand', function () {
     await expect(txnDecAndStore.wait()).to.not.be.rejected;
   });
 
+  it('16 bits generate with upper bound, decrypt and store', async function () {
+    const txnGen = await this.rand.generate16UpperBound(4096);
+    await txnGen.wait();
+    const txnDecAndStore = await this.rand.decryptAndStore16();
+    await expect(txnDecAndStore.wait()).to.not.be.rejected;
+  });
+
   it('32 bits generate, decrypt and store', async function () {
     const txnGen = await this.rand.generate32();
+    await txnGen.wait();
+    const txnDecAndStore = await this.rand.decryptAndStore32();
+    await expect(txnDecAndStore.wait()).to.not.be.rejected;
+  });
+
+  it('32 bits generate with upper bound, decrypt and store', async function () {
+    const txnGen = await this.rand.generate32UpperBound(32768);
     await txnGen.wait();
     const txnDecAndStore = await this.rand.decryptAndStore32();
     await expect(txnDecAndStore.wait()).to.not.be.rejected;
@@ -99,15 +162,33 @@ describe('Rand', function () {
     }
   });
 
+  it('8 bits with upper bound in view', async function () {
+    if (process.env.HARDHAT_NETWORK !== 'hardhat') {
+      await expect(this.rand.generate8UpperBoundInView(32)).to.be.rejected;
+    }
+  });
+
   it('16 bits in view', async function () {
     if (process.env.HARDHAT_NETWORK !== 'hardhat') {
       await expect(this.rand.generate16InView()).to.be.rejected;
     }
   });
 
+  it('16 bits with upper bound in view', async function () {
+    if (process.env.HARDHAT_NETWORK !== 'hardhat') {
+      await expect(this.rand.generate16UpperBoundInView(128)).to.be.rejected;
+    }
+  });
+
   it('32 bits in view', async function () {
     if (process.env.HARDHAT_NETWORK !== 'hardhat') {
       await expect(this.rand.generate32InView()).to.be.rejected;
+    }
+  });
+
+  it('32 bits with upper bound in view', async function () {
+    if (process.env.HARDHAT_NETWORK !== 'hardhat') {
+      await expect(this.rand.generate32UpperBoundInView(512)).to.be.rejected;
     }
   });
 });


### PR DESCRIPTION
Add overloads of TFHE.randEuint() methods that accept an upper bound, e.g. TFHE.randEuint32(uint32 upperBound). The returned integer will be in the [0, upperBound) range. Moreover, upperBound must be a power of 2 - that is a design choice for performance reasons.

Note that, as of now, the random numbers are generated in the plain and are completely public and predictable. An FHE version is coming soon.

Add tests to cover above functionality.