### PR TITLE
made changes for correcting shift operators in tfhe sol

### DIFF
--- a/codegen/common.ts
+++ b/codegen/common.ts
@@ -21,6 +21,7 @@ export type Operator = {
   fheLibName?: string;
   binarySolidityOperator?: string;
   unarySolidityOperator?: string;
+  shiftOperator?: boolean;
 };
 
 export type CodegenContext = {
@@ -125,6 +126,7 @@ export const ALL_OPERATORS: Operator[] = [
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
     leftScalarEncrypt: true,
+    shiftOperator: true,
   },
   {
     name: 'shr',
@@ -134,6 +136,7 @@ export const ALL_OPERATORS: Operator[] = [
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
     leftScalarEncrypt: true,
+    shiftOperator: true,
   },
   {
     name: 'eq',

--- a/codegen/overloadTests.ts
+++ b/codegen/overloadTests.ts
@@ -121,7 +121,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0xff, 0xffff], output: 0xff00 },
     { inputs: [0xff, 0xff00], output: 0xffff },
   ],
-  shl_euint8_euint16: [
+  /*shl_euint8_euint16: [
     // TODO: should shl output 8bit with 16bit be like that?
     { inputs: [0xff, 0x0100], output: 0xff },
     { inputs: [0x02, 0x0001], output: 0x04 },
@@ -130,7 +130,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     // TODO: should shr output 8bit with 16bit be like that?
     { inputs: [0xff, 0x0100], output: 0xff },
     { inputs: [0xff, 0x0001], output: 0x7f },
-  ],
+  ],*/
   eq_euint8_euint16: [
     { inputs: [0xff, 0x00ff], output: true },
     { inputs: [0xff, 0x01ff], output: false },
@@ -187,7 +187,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10, 0x00010000], output: 0x00010010 },
     { inputs: [0x11, 0x00010010], output: 0x00010001 },
   ],
-  shl_euint8_euint32: [
+  /*shl_euint8_euint32: [
     // C compiler emits the same
     { inputs: [0x10, 0x00010000], output: 0x10 },
     { inputs: [0x1f, 0x00010000], output: 0x1f },
@@ -198,7 +198,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x1f, 0x00010000], output: 0x1f },
     { inputs: [0x10, 0x00000001], output: 0x8 },
     { inputs: [0x1f, 0x00000001], output: 0xf },
-  ],
+  ],*/
   eq_euint8_euint32: [
     { inputs: [0x01, 0x00000001], output: true },
     { inputs: [0x01, 0x00010001], output: false },
@@ -375,7 +375,11 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10f0, 0xf2], output: 0x1002 },
   ],
   shl_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
+  shl_uint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
+  shl_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
   shr_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
+  shr_uint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
+  shr_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
   eq_euint16_euint8: [
     { inputs: [0x0010, 0x10], output: true },
     { inputs: [0x0110, 0x10], output: false },
@@ -429,8 +433,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0200, 0x0002], output: 0x0202 },
     { inputs: [0x0210, 0x0012], output: 0x0202 },
   ],
-  shl_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0800 }],
-  shr_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0080 }],
+  /*shl_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0800 }],
+  shr_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0080 }],*/
   eq_euint16_euint16: [
     { inputs: [0x0200, 0x0002], output: false },
     { inputs: [0x0200, 0x0200], output: true },
@@ -487,8 +491,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0202, 0x00010000], output: 0x00010202 },
     { inputs: [0x0202, 0x00010002], output: 0x00010200 },
   ],
-  shl_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000808 }],
-  shr_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000080 }],
+  /*shl_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000808 }],
+  shr_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000080 }],*/
   eq_euint16_euint32: [
     { inputs: [0x0202, 0x00010202], output: false },
     { inputs: [0x0202, 0x00000202], output: true },
@@ -535,10 +539,10 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint16_euint16: [{ inputs: [0x0202, 0x0003], output: 0x0606 }],
   div_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x0202 }],
   rem_euint16_uint16: [{ inputs: [0x0608, 0x0003], output: 0x0002 }],
-  shl_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
+  /*shl_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
   shl_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
   shr_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],
-  shr_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],
+  shr_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],*/
   eq_euint16_uint16: [
     { inputs: [0x0606, 0x0606], output: true },
     { inputs: [0x0606, 0x0605], output: false },
@@ -631,7 +635,11 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03010003, 0x03], output: 0x03010000 },
   ],
   shl_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
+  shl_uint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
+  shl_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
   shr_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
+  shr_uint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
+  shr_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
   eq_euint32_euint8: [
     { inputs: [0x00000003, 0x03], output: true },
     { inputs: [0x03000003, 0x03], output: false },
@@ -682,8 +690,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03000023, 0x1003], output: 0x03001023 },
   ],
   xor_euint32_euint16: [{ inputs: [0x03000023, 0x1003], output: 0x03001020 }],
-  shl_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x0c000000 }],
-  shr_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x00c00000 }],
+  /*shl_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x0c000000 }],
+  shr_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x00c00000 }],*/
   eq_euint32_euint16: [
     { inputs: [0x00001000, 0x1000], output: true },
     { inputs: [0x01001000, 0x1000], output: false },
@@ -737,8 +745,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x00321000, 0x54000000], output: 0x54321000 },
     { inputs: [0x00321000, 0x54030000], output: 0x54311000 },
   ],
-  shl_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x00c84000 }],
-  shr_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x000c8400 }],
+  /*shl_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x00c84000 }],
+  shr_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x000c8400 }],*/
   eq_euint32_euint32: [
     { inputs: [0x00321000, 0x00321000], output: true },
     { inputs: [0x00321000, 0x00321001], output: false },
@@ -785,10 +793,10 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint32_euint32: [{ inputs: [0x00342000, 0x00000100], output: 0x34200000 }],
   div_euint32_uint32: [{ inputs: [0x00342000, 0x00000100], output: 0x00003420 }],
   rem_euint32_uint32: [{ inputs: [0x00342039, 0x00000100], output: 0x00000039 }],
-  shl_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
+  /*shl_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
   shl_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
   shr_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],
-  shr_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],
+  shr_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],*/
   eq_euint32_uint32: [
     { inputs: [0x00342000, 0x00342000], output: true },
     { inputs: [0x00342000, 0x00342001], output: false },

--- a/codegen/overloadTests.ts
+++ b/codegen/overloadTests.ts
@@ -121,16 +121,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0xff, 0xffff], output: 0xff00 },
     { inputs: [0xff, 0xff00], output: 0xffff },
   ],
-  /*shl_euint8_euint16: [
-    // TODO: should shl output 8bit with 16bit be like that?
-    { inputs: [0xff, 0x0100], output: 0xff },
-    { inputs: [0x02, 0x0001], output: 0x04 },
-  ],
-  shr_euint8_euint16: [
-    // TODO: should shr output 8bit with 16bit be like that?
-    { inputs: [0xff, 0x0100], output: 0xff },
-    { inputs: [0xff, 0x0001], output: 0x7f },
-  ],*/
   eq_euint8_euint16: [
     { inputs: [0xff, 0x00ff], output: true },
     { inputs: [0xff, 0x01ff], output: false },
@@ -187,18 +177,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10, 0x00010000], output: 0x00010010 },
     { inputs: [0x11, 0x00010010], output: 0x00010001 },
   ],
-  /*shl_euint8_euint32: [
-    // C compiler emits the same
-    { inputs: [0x10, 0x00010000], output: 0x10 },
-    { inputs: [0x1f, 0x00010000], output: 0x1f },
-  ],
-  shr_euint8_euint32: [
-    // C compiler emits the same
-    { inputs: [0x10, 0x00010000], output: 0x10 },
-    { inputs: [0x1f, 0x00010000], output: 0x1f },
-    { inputs: [0x10, 0x00000001], output: 0x8 },
-    { inputs: [0x1f, 0x00000001], output: 0xf },
-  ],*/
   eq_euint8_euint32: [
     { inputs: [0x01, 0x00000001], output: true },
     { inputs: [0x01, 0x00010001], output: false },
@@ -265,15 +243,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10, 0x01], output: 0x20 },
     { inputs: [0x10, 0x02], output: 0x40 },
   ],
-  shl_uint8_euint8: [
-    { inputs: [0x10, 0x01], output: 0x20 },
-    { inputs: [0x10, 0x02], output: 0x40 },
-  ],
   shr_euint8_uint8: [
-    { inputs: [0x10, 0x01], output: 0x08 },
-    { inputs: [0x10, 0x02], output: 0x04 },
-  ],
-  shr_uint8_euint8: [
     { inputs: [0x10, 0x01], output: 0x08 },
     { inputs: [0x10, 0x02], output: 0x04 },
   ],
@@ -375,10 +345,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10f0, 0xf2], output: 0x1002 },
   ],
   shl_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
-  shl_uint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
   shl_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
   shr_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
-  shr_uint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
   shr_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
   eq_euint16_euint8: [
     { inputs: [0x0010, 0x10], output: true },
@@ -433,8 +401,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0200, 0x0002], output: 0x0202 },
     { inputs: [0x0210, 0x0012], output: 0x0202 },
   ],
-  /*shl_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0800 }],
-  shr_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0080 }],*/
   eq_euint16_euint16: [
     { inputs: [0x0200, 0x0002], output: false },
     { inputs: [0x0200, 0x0200], output: true },
@@ -491,8 +457,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0202, 0x00010000], output: 0x00010202 },
     { inputs: [0x0202, 0x00010002], output: 0x00010200 },
   ],
-  /*shl_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000808 }],
-  shr_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000080 }],*/
   eq_euint16_euint32: [
     { inputs: [0x0202, 0x00010202], output: false },
     { inputs: [0x0202, 0x00000202], output: true },
@@ -539,10 +503,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint16_euint16: [{ inputs: [0x0202, 0x0003], output: 0x0606 }],
   div_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x0202 }],
   rem_euint16_uint16: [{ inputs: [0x0608, 0x0003], output: 0x0002 }],
-  /*shl_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
-  shl_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
-  shr_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],
-  shr_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],*/
   eq_euint16_uint16: [
     { inputs: [0x0606, 0x0606], output: true },
     { inputs: [0x0606, 0x0605], output: false },
@@ -635,10 +595,8 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03010003, 0x03], output: 0x03010000 },
   ],
   shl_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
-  shl_uint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
   shl_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
   shr_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
-  shr_uint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
   shr_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
   eq_euint32_euint8: [
     { inputs: [0x00000003, 0x03], output: true },
@@ -690,8 +648,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03000023, 0x1003], output: 0x03001023 },
   ],
   xor_euint32_euint16: [{ inputs: [0x03000023, 0x1003], output: 0x03001020 }],
-  /*shl_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x0c000000 }],
-  shr_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x00c00000 }],*/
   eq_euint32_euint16: [
     { inputs: [0x00001000, 0x1000], output: true },
     { inputs: [0x01001000, 0x1000], output: false },
@@ -745,8 +701,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x00321000, 0x54000000], output: 0x54321000 },
     { inputs: [0x00321000, 0x54030000], output: 0x54311000 },
   ],
-  /*shl_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x00c84000 }],
-  shr_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x000c8400 }],*/
   eq_euint32_euint32: [
     { inputs: [0x00321000, 0x00321000], output: true },
     { inputs: [0x00321000, 0x00321001], output: false },
@@ -793,10 +747,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint32_euint32: [{ inputs: [0x00342000, 0x00000100], output: 0x34200000 }],
   div_euint32_uint32: [{ inputs: [0x00342000, 0x00000100], output: 0x00003420 }],
   rem_euint32_uint32: [{ inputs: [0x00342039, 0x00000100], output: 0x00000039 }],
-  /*shl_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
-  shl_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
-  shr_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],
-  shr_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],*/
   eq_euint32_uint32: [
     { inputs: [0x00342000, 0x00342000], output: true },
     { inputs: [0x00342000, 0x00342001], output: false },

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -473,7 +473,7 @@ function tfheAsEboolUnaryCast(bits: number): string {
     }
 
     function not(ebool a) internal pure returns (ebool) {
-        return asEbool(not(asEuint8(a)));
+        return asEbool(and(not(asEuint8(a)), asEuint8(1)));
     }
     
     // If 'control''s value is 'true', the result has the same value as 'a'.

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -280,8 +280,8 @@ function tfheEncryptedOperator(
     operator.returnType == ReturnType.Uint
       ? `euint${outputBits}`
       : operator.returnType == ReturnType.Ebool
-        ? `ebool`
-        : assert(false, 'Unknown return type');
+      ? `ebool`
+      : assert(false, 'Unknown return type');
   const returnTypeOverload: ArgumentType =
     operator.returnType == ReturnType.Uint ? ArgumentType.EUint : ArgumentType.Ebool;
   const scalarFlag = operator.hasEncrypted && operator.hasScalar ? ', false' : '';
@@ -338,8 +338,8 @@ function tfheScalarOperator(
     operator.returnType == ReturnType.Uint
       ? `euint${outputBits}`
       : operator.returnType == ReturnType.Ebool
-        ? `ebool`
-        : assert(false, 'Unknown return type');
+      ? `ebool`
+      : assert(false, 'Unknown return type');
   const returnTypeOverload = operator.returnType == ReturnType.Uint ? ArgumentType.EUint : ArgumentType.Ebool;
   var scalarFlag = operator.hasEncrypted && operator.hasScalar ? ', true' : '';
   const leftOpName = operator.leftScalarInvertOp ?? operator.name;

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -475,26 +475,6 @@ function tfheShiftOperators(inputBits: number, operator: Operator, signatures: O
     }
   `);
 
-  // Code and test for shift(uint{inputBits},euint8}
-  signatures.push({
-    name: operator.name,
-    arguments: [
-      { type: ArgumentType.Uint, bits: lhsBits },
-      { type: ArgumentType.EUint, bits: rhsBits },
-    ],
-    returnType: { type: returnTypeOverload, bits: outputBits },
-  });
-  res.push(`
-
-  // Evaluate ${operator.name}(a, b) and return the result.
-  function ${operator.name}(uint${lhsBits} a, euint${rhsBits} b) internal pure returns (${returnType}) {
-      ${maybeEncryptLeft}
-      if (!isInitialized(b)) {
-          b = asEuint${rhsBits}(0);
-      }
-      return ${returnType}.wrap(${implExpressionB});
-  }
-      `);
   return res.join('');
 }
 

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -170,9 +170,19 @@ library TFHE {
 
   supportedBits.forEach((lhsBits) => {
     supportedBits.forEach((rhsBits) => {
-      operators.forEach((operator) => res.push(tfheEncryptedOperator(lhsBits, rhsBits, operator, signatures)));
+      operators.forEach((operator) => {
+        if (!operator.shiftOperator) res.push(tfheEncryptedOperator(lhsBits, rhsBits, operator, signatures));
+      });
     });
-    operators.forEach((operator) => res.push(tfheScalarOperator(lhsBits, lhsBits, operator, signatures)));
+    operators.forEach((operator) => {
+      if (!operator.shiftOperator) res.push(tfheScalarOperator(lhsBits, lhsBits, operator, signatures));
+    });
+  });
+
+  supportedBits.forEach((bits) => {
+    operators.forEach((operator) => {
+      if (operator.shiftOperator) res.push(tfheShiftOperators(bits, operator, signatures));
+    });
   });
 
   // TODO: Decide whether we want to have mixed-inputs for CMUX
@@ -270,8 +280,8 @@ function tfheEncryptedOperator(
     operator.returnType == ReturnType.Uint
       ? `euint${outputBits}`
       : operator.returnType == ReturnType.Ebool
-      ? `ebool`
-      : assert(false, 'Unknown return type');
+        ? `ebool`
+        : assert(false, 'Unknown return type');
   const returnTypeOverload: ArgumentType =
     operator.returnType == ReturnType.Uint ? ArgumentType.EUint : ArgumentType.Ebool;
   const scalarFlag = operator.hasEncrypted && operator.hasScalar ? ', false' : '';
@@ -328,8 +338,8 @@ function tfheScalarOperator(
     operator.returnType == ReturnType.Uint
       ? `euint${outputBits}`
       : operator.returnType == ReturnType.Ebool
-      ? `ebool`
-      : assert(false, 'Unknown return type');
+        ? `ebool`
+        : assert(false, 'Unknown return type');
   const returnTypeOverload = operator.returnType == ReturnType.Uint ? ArgumentType.EUint : ArgumentType.Ebool;
   var scalarFlag = operator.hasEncrypted && operator.hasScalar ? ', true' : '';
   const leftOpName = operator.leftScalarInvertOp ?? operator.name;
@@ -392,6 +402,99 @@ function tfheScalarOperator(
         `);
   }
 
+  return res.join('');
+}
+
+function tfheShiftOperators(inputBits: number, operator: Operator, signatures: OverloadSignature[]): string {
+  const res: string[] = [];
+
+  // Code and test for shift(euint{inputBits},euint8}
+  const outputBits = inputBits;
+  const lhsBits = inputBits;
+  const rhsBits = 8;
+  const castRightToLeft = lhsBits > rhsBits;
+
+  const returnType = `euint${outputBits}`;
+
+  const returnTypeOverload: ArgumentType = ArgumentType.EUint;
+  let scalarFlag = ', false';
+
+  const leftExpr = 'a';
+  const rightExpr = castRightToLeft ? `asEuint${outputBits}(b)` : 'b';
+  let implExpression = `Impl.${operator.name}(euint${outputBits}.unwrap(${leftExpr}), euint${outputBits}.unwrap(${rightExpr})${scalarFlag})`;
+
+  signatures.push({
+    name: operator.name,
+    arguments: [
+      { type: ArgumentType.EUint, bits: lhsBits },
+      { type: ArgumentType.EUint, bits: rhsBits },
+    ],
+    returnType: { type: returnTypeOverload, bits: outputBits },
+  });
+  res.push(`
+    // Evaluate ${operator.name}(a, b) and return the result.
+    function ${operator.name}(euint${lhsBits} a, euint${rhsBits} b) internal pure returns (${returnType}) {
+        if (!isInitialized(a)) {
+            a = asEuint${lhsBits}(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint${rhsBits}(0);
+        }
+        return ${returnType}.wrap(${implExpression});
+    }
+`);
+
+  // Code and test for shift(euint{inputBits},uint8}
+  scalarFlag = ', true';
+  const leftOpName = operator.name;
+  var implExpressionA = `Impl.${operator.name}(euint${outputBits}.unwrap(a), uint256(b)${scalarFlag})`;
+  var implExpressionB = `Impl.${leftOpName}(euint${outputBits}.unwrap(b), uint256(a)${scalarFlag})`;
+  var maybeEncryptLeft = '';
+  if (operator.leftScalarEncrypt) {
+    // workaround until tfhe-rs left scalar support:
+    // do the trivial encryption and preserve order of operations
+    scalarFlag = ', false';
+    maybeEncryptLeft = `euint${outputBits} aEnc = asEuint${outputBits}(a);`;
+    implExpressionB = `Impl.${leftOpName}(euint${outputBits}.unwrap(aEnc), euint${8}.unwrap(b)${scalarFlag})`;
+  }
+  signatures.push({
+    name: operator.name,
+    arguments: [
+      { type: ArgumentType.EUint, bits: lhsBits },
+      { type: ArgumentType.Uint, bits: rhsBits },
+    ],
+    returnType: { type: returnTypeOverload, bits: outputBits },
+  });
+  res.push(`
+    // Evaluate ${operator.name}(a, b) and return the result.
+    function ${operator.name}(euint${lhsBits} a, uint${rhsBits} b) internal pure returns (${returnType}) {
+        if (!isInitialized(a)) {
+            a = asEuint${lhsBits}(0);
+        }
+        return ${returnType}.wrap(${implExpressionA});
+    }
+  `);
+
+  // Code and test for shift(uint{inputBits},euint8}
+  signatures.push({
+    name: operator.name,
+    arguments: [
+      { type: ArgumentType.Uint, bits: lhsBits },
+      { type: ArgumentType.EUint, bits: rhsBits },
+    ],
+    returnType: { type: returnTypeOverload, bits: outputBits },
+  });
+  res.push(`
+
+  // Evaluate ${operator.name}(a, b) and return the result.
+  function ${operator.name}(uint${lhsBits} a, euint${rhsBits} b) internal pure returns (${returnType}) {
+      ${maybeEncryptLeft}
+      if (!isInitialized(b)) {
+          b = asEuint${rhsBits}(0);
+      }
+      return ${returnType}.wrap(${implExpressionB});
+  }
+      `);
   return res.join('');
 }
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Condition](solidity/condition.md)
 - [Decryption and reencryption](solidity/decrypt.md)
 - [Function specifications](solidity/functions.md)
+- [Troubleshooting](solidity/troubleshooting.md)
 - [Roadmap](solidity/roadmap.md)
 - [Examples](solidity/examples.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,7 +30,7 @@
 - [Getting started](client/getting_started.md)
   - [Node](client/getting_started/node.md)
   - [Browser](client/getting_started/browser.md)
-  - [Template](client/getting_started/template.md)
+  - [Templates](client/getting_started/templates.md)
   - [CLI](client/getting_started/cli.md)
 - [Setup an instance](client/instance.md)
 - [Inputs](client/inputs.md)

--- a/docs/client/getting_started/template.md
+++ b/docs/client/getting_started/template.md
@@ -1,5 +1,0 @@
-# Template
-
-## React
-
-You can use [this template](https://github.com/zama-ai/fhevmjs-react-template) to start an application with fhevmjs, using Vite + React + Typescript.

--- a/docs/client/getting_started/templates.md
+++ b/docs/client/getting_started/templates.md
@@ -1,0 +1,9 @@
+# Templates
+
+## React
+
+You can use [this template](https://github.com/zama-ai/fhevmjs-react-template) to start an application with fhevmjs, using Vite + React + Typescript.
+
+## VueJS
+
+You can also use [this template](https://github.com/zama-ai/fhevmjs-vue-template) to start an application with fhevmjs, using Vite + Vue + Typescript.

--- a/docs/solidity/getting_started/remix.md
+++ b/docs/solidity/getting_started/remix.md
@@ -17,6 +17,13 @@ To import TFHE library, simply import it at the top of your contract.
 
 `import "fhevm/lib/TFHE.sol";`
 
+**UPDATE**: Remix doesn't take into consideration the package.json of fhevm to fetch dependencies. If you're using `fhevm/abstracts/EIP712WithModifier.sol`, it will fetch the latest version of the `@openzeppelin/contracts` package, which runs only on the Shanghai EVM (Solidity version ^0.8.20). Since fhEVM is not compatible with versions above 0.8.19, it will fail. To fix that, go to `.deps/fhevm/abstracts/EIP712WithModifier.sol` and change the imports as follows:
+
+```solidity
+import "@openzeppelin/contracts@4.9.3/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts@4.9.3/utils/cryptography/EIP712.sol";
+```
+
 Be sure to be on the correct network before deploying your contract
 
 <figure><img src="../../.gitbook/assets/metamask_select_network.png" alt="" width="300"><figcaption>
@@ -24,3 +31,4 @@ Choose the Zama Devnet</figcaption></figure>
 
 <figure><img src="../../.gitbook/assets/remix_deploy.png" alt="" width="300"><figcaption>
 Choose "Injected Provider - Metamask"</figcaption></figure>
+````

--- a/docs/solidity/troubleshooting.md
+++ b/docs/solidity/troubleshooting.md
@@ -11,7 +11,7 @@ In Metamask, you can enforce the use of a specific nonce by enabling the feature
 
 When you include a require statement in a transaction like `require(TFHE.decrypt(ebool), "It didn't work");`, the revert message will not be returned if `ebool` is false.
 
-### My transaction seems to be reverted randomly
+### My transaction seems to be reverted randomly (or silently)
 
 When you invoke the gas estimation method, fhEVM may not provide an accurate estimation if your code includes `TFHE.decrypt` because it is unable to determine the actual value. In such cases, the gas estimation assumes that `TFHE.decrypt()` returns `1`. Depending on your code, this assumption may lead to a deviation from the actual gas usage. To mitigate this, consider adding a 20% buffer to the gas estimation or more. However, be cautious not to exceed 10,000,000 as the upper limit. We've written a method, available in the hardhat template, to tackle this issue. Feel free to use it.
 
@@ -42,16 +42,25 @@ euint32 constant private MY_CONSTANT = TFHE.asEuint32(42);
 
 The `TFHE.asEuint32(42)` will be executed during compilation to evaluate your property `MY_CONSTANT`, because the compiler expect to have an actual value. Since you're not calling the precompiles which would return a trivial encryption of `42`, you get a `0` value.
 
-## Event
+### I return bytes of the ciphertext, but the ciphertext is very small.
+
+In the contract, obtaining the bytes of the ciphertext is not possible. As outlined in [our whitepaper](https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper.pdf), you manipulate the hash of the ciphertext in the EVM; the actual ciphertext is only utilized when interacting with the precompiles (`TFHE.decrypt`, `TFHE.add`, ...).
+
+## Blockchain
+
+### I get the error "fhePubKey FHE public key hash doesn't match one stored in state"
+
+This error occurs when you haven't yet published any contracts on the blockchain. To resolve this, simply deploy a contract on the blockchain.
 
 ### How can I listen to blockchain events?
 
-Libraries like ethers enable event listening through HTTP polling. However, it is important to note that this functionality is limited to a `JsonRpcProvider` and is not compatible with the `BrowserProvider` you'd use if you develop with user's browser wallet.
+You can listen for events using WebSocket on port `8546` of your local Docker image. Alternatively, if you prefer to do it on Zama's devnet, you can use the WebSocket server available at `wss://devnet.ws.zama.ai/`.
 
 ```javascript
-const provider = new BrowserProvider(window.metamask);
-const jsonRpcProvider = new JsonRpcProvider("https://devnet.zama.ai");
-const contract = new Contract(address, abi, await provider.getSigner());
+const WEBSOCKET_URL = "ws://localhost:8546/";
+// const WEBSOCKET_URL = 'wss://devnet.ws.zama.ai/';
+const wsProvider = new WebsocketProvider(WEBSOCKET_URL);
+const contract = new Contract(address, abi, await wsProvider.getSigner());
 contract.on(contract.filters.GameLaunched, () => {
   console.log("A new game has been launched");
 });

--- a/docs/solidity/troubleshooting.md
+++ b/docs/solidity/troubleshooting.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## How to cancel a stuck transaction?
+
+The current devnet has a gas limit of 10,000,000. If you send a transaction exceeding this limit, it won't be executed. Consequently, your wallet won't be able to emit a new transaction. To address this, emit a new transaction with the same nonce but the correct gas limit.
+In Metamask, you can enforce the use of a specific nonce by enabling the feature in 'Advanced Settings'.
+
+## How can I listen to blockchain events?
+
+Libraries like ethers enable event listening through HTTP polling. However, it is important to note that this functionality is limited to a `JsonRpcProvider` and is not compatible with the `BrowserProvider` you'd use if you develop with user's browser wallet.
+
+```javascript
+const provider = new BrowserProvider(window.metamask);
+const jsonRpcProvider = new JsonRpcProvider("https://devnet.zama.ai");
+const contract = new Contract(address, abi, await provider.getSigner());
+contract.on("NewGame", () => {
+  console.log("A new game has been launched");
+});
+```
+
+## My transaction reverts but I can't get the error message
+
+When you include a require statement in a transaction like `require(TFHE.decrypt(ebool), "It didn't work");`, the revert message will not be returned if `ebool` is false.
+
+## I've defined certain constants as properties, but it appears that I'm unable to utilize them."
+
+First, to understand the issue, you need to know that a `euint32` or a `ebool` are `uint256` under the hood: they are a 256bits hash of the actual ciphertext.
+So if you set your properties directly in the contract as follows:
+
+```
+euint32 constant private MY_CONSTANT = TFHE.asEuint32(42);
+```
+
+The `TFHE.asEuint32(42)` will be executed during compilation to evaluate your property `MY_CONSTANT`, because the compiler expect to have an actual value. Since you're not calling the precompiles which would return a trivial encryption of `42`, you get a `0` value.

--- a/docs/solidity/troubleshooting.md
+++ b/docs/solidity/troubleshooting.md
@@ -1,28 +1,37 @@
 # Troubleshooting
 
-## How to cancel a stuck transaction?
+## Transaction
+
+### How to cancel a stuck transaction?
 
 The current devnet has a gas limit of 10,000,000. If you send a transaction exceeding this limit, it won't be executed. Consequently, your wallet won't be able to emit a new transaction. To address this, emit a new transaction with the same nonce but the correct gas limit.
 In Metamask, you can enforce the use of a specific nonce by enabling the feature in 'Advanced Settings'.
 
-## How can I listen to blockchain events?
-
-Libraries like ethers enable event listening through HTTP polling. However, it is important to note that this functionality is limited to a `JsonRpcProvider` and is not compatible with the `BrowserProvider` you'd use if you develop with user's browser wallet.
-
-```javascript
-const provider = new BrowserProvider(window.metamask);
-const jsonRpcProvider = new JsonRpcProvider("https://devnet.zama.ai");
-const contract = new Contract(address, abi, await provider.getSigner());
-contract.on("NewGame", () => {
-  console.log("A new game has been launched");
-});
-```
-
-## My transaction reverts but I can't get the error message
+### My transaction reverts but I can't get the error message
 
 When you include a require statement in a transaction like `require(TFHE.decrypt(ebool), "It didn't work");`, the revert message will not be returned if `ebool` is false.
 
-## I've defined certain constants as properties, but it appears that I'm unable to utilize them."
+### My transaction seems to be reverted randomly
+
+When you invoke the gas estimation method, fhEVM may not provide an accurate estimation if your code includes `TFHE.decrypt` because it is unable to determine the actual value. In such cases, the gas estimation assumes that `TFHE.decrypt()` returns `1`. Depending on your code, this assumption may lead to a deviation from the actual gas usage. To mitigate this, consider adding a 20% buffer to the gas estimation or more. However, be cautious not to exceed 10,000,000 as the upper limit. We've written a method, available in the hardhat template, to tackle this issue. Feel free to use it.
+
+```typescript
+export const createTransaction = async <A extends [...{ [I in keyof A]-?: A[I] | Typed }]>(
+  method: TypedContractMethod<A>,
+  ...params: A
+) => {
+  const gasLimit = await method.estimateGas(...params);
+  const updatedParams: ContractMethodArgs<A> = [
+    ...params,
+    { gasLimit: Math.min(Math.round(+gasLimit.toString() * 1.2), 10000000) },
+  ];
+  return method(...updatedParams);
+};
+```
+
+## Contract
+
+### I've defined certain constants as properties, but it appears that I'm unable to utilize them.
 
 First, to understand the issue, you need to know that a `euint32` or a `ebool` are `uint256` under the hood: they are a 256bits hash of the actual ciphertext.
 So if you set your properties directly in the contract as follows:
@@ -32,3 +41,18 @@ euint32 constant private MY_CONSTANT = TFHE.asEuint32(42);
 ```
 
 The `TFHE.asEuint32(42)` will be executed during compilation to evaluate your property `MY_CONSTANT`, because the compiler expect to have an actual value. Since you're not calling the precompiles which would return a trivial encryption of `42`, you get a `0` value.
+
+## Event
+
+### How can I listen to blockchain events?
+
+Libraries like ethers enable event listening through HTTP polling. However, it is important to note that this functionality is limited to a `JsonRpcProvider` and is not compatible with the `BrowserProvider` you'd use if you develop with user's browser wallet.
+
+```javascript
+const provider = new BrowserProvider(window.metamask);
+const jsonRpcProvider = new JsonRpcProvider("https://devnet.zama.ai");
+const contract = new Contract(address, abi, await provider.getSigner());
+contract.on(contract.filters.GameLaunched, () => {
+  console.log("A new game has been launched");
+});
+```

--- a/examples/tests/TFHEManualTestSuite.sol
+++ b/examples/tests/TFHEManualTestSuite.sol
@@ -33,4 +33,20 @@ contract TFHEManualTestSuite {
         TFHE.optReq(TFHE.asEbool(input));
         counter += 1;
     }
+
+    function test_ebool_not(bool input) public view returns (bool) {
+        return TFHE.decrypt(TFHE.not(TFHE.asEbool(input)));
+    }
+
+    function test_ebool_and(bool a, bool b) public view returns (bool) {
+        return TFHE.decrypt(TFHE.and(TFHE.asEbool(a), TFHE.asEbool(b)));
+    }
+
+    function test_ebool_or(bool a, bool b) public view returns (bool) {
+        return TFHE.decrypt(TFHE.or(TFHE.asEbool(a), TFHE.asEbool(b)));
+    }
+
+    function test_ebool_xor(bool a, bool b) public view returns (bool) {
+        return TFHE.decrypt(TFHE.xor(TFHE.asEbool(a), TFHE.asEbool(b)));
+    }
 }

--- a/examples/tests/TFHETestSuite1.sol
+++ b/examples/tests/TFHETestSuite1.sol
@@ -46,20 +46,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint8 aProc = TFHE.asEuint8(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -158,20 +144,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint8 aProc = TFHE.asEuint8(a);
         euint16 bProc = TFHE.asEuint16(b);
@@ -267,20 +239,6 @@ contract TFHETestSuite1 {
         euint8 aProc = TFHE.asEuint8(a);
         euint32 bProc = TFHE.asEuint32(b);
         euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint8_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -393,34 +351,6 @@ contract TFHETestSuite1 {
         euint8 aProc = TFHE.asEuint8(a);
         uint8 bProc = b;
         euint8 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        uint8 bProc = b;
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        uint8 bProc = b;
-        euint8 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -578,20 +508,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -690,17 +606,101 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+    function eq_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
+        ebool result = TFHE.eq(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+    function ne_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        euint16 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        euint16 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function and_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.and(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function or_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.or(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function xor_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.xor(aProc, bProc);
         return TFHE.decrypt(result);
     }
 }

--- a/examples/tests/TFHETestSuite2.sol
+++ b/examples/tests/TFHETestSuite2.sol
@@ -4,118 +4,6 @@ pragma solidity 0.8.19;
 import "../../lib/TFHE.sol";
 
 contract TFHETestSuite2 {
-    function eq_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.max(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function add_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function and_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.and(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function or_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.or(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function xor_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint32 bProc = TFHE.asEuint32(b);
@@ -225,34 +113,6 @@ contract TFHETestSuite2 {
         euint16 aProc = TFHE.asEuint16(a);
         uint16 bProc = b;
         euint16 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint16_uint16(bytes calldata a, uint16 b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        uint16 bProc = b;
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_uint16_euint16(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_uint16(bytes calldata a, uint16 b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        uint16 bProc = b;
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint16_euint16(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -410,20 +270,6 @@ contract TFHETestSuite2 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint32 aProc = TFHE.asEuint32(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -519,20 +365,6 @@ contract TFHETestSuite2 {
         euint32 aProc = TFHE.asEuint32(a);
         euint16 bProc = TFHE.asEuint16(b);
         euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint32_euint16(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint16(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -634,20 +466,6 @@ contract TFHETestSuite2 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint32 aProc = TFHE.asEuint32(a);
         euint32 bProc = TFHE.asEuint32(b);
@@ -701,6 +519,188 @@ contract TFHETestSuite2 {
         euint32 aProc = TFHE.asEuint32(a);
         euint32 bProc = TFHE.asEuint32(b);
         euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function div_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.div(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function rem_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.rem(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function eq_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.eq(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function eq_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.eq(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ne_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ne_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        uint8 bProc = b;
+        euint8 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 }

--- a/examples/tests/TFHETestSuite3.sol
+++ b/examples/tests/TFHETestSuite3.sol
@@ -4,13 +4,6 @@ pragma solidity 0.8.19;
 import "../../lib/TFHE.sol";
 
 contract TFHETestSuite3 {
-    function shl_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function shr_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
         euint8 aProc = TFHE.asEuint8(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -21,13 +14,6 @@ contract TFHETestSuite3 {
     function shr_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
         euint8 aProc = TFHE.asEuint8(a);
         uint8 bProc = b;
-        euint8 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
         euint8 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
@@ -46,13 +32,6 @@ contract TFHETestSuite3 {
         return TFHE.decrypt(result);
     }
 
-    function shl_uint16_euint8(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function shr_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
         euint16 aProc = TFHE.asEuint16(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -63,13 +42,6 @@ contract TFHETestSuite3 {
     function shr_euint16_uint8(bytes calldata a, uint8 b) public view returns (uint16) {
         euint16 aProc = TFHE.asEuint16(a);
         uint8 bProc = b;
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint16_euint8(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
         euint16 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
@@ -88,13 +60,6 @@ contract TFHETestSuite3 {
         return TFHE.decrypt(result);
     }
 
-    function shl_uint32_euint8(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function shr_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -105,13 +70,6 @@ contract TFHETestSuite3 {
     function shr_euint32_uint8(bytes calldata a, uint8 b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
         uint8 bProc = b;
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint32_euint8(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
         euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }

--- a/examples/tests/TFHETestSuite3.sol
+++ b/examples/tests/TFHETestSuite3.sol
@@ -4,199 +4,115 @@ pragma solidity 0.8.19;
 import "../../lib/TFHE.sol";
 
 contract TFHETestSuite3 {
-    function add_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+    function shl_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
+        uint8 aProc = a;
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        uint8 bProc = b;
+        euint8 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
+        uint8 aProc = a;
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint16_uint8(bytes calldata a, uint8 b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        uint8 bProc = b;
+        euint16 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_uint16_euint8(uint16 a, bytes calldata b) public view returns (uint16) {
+        uint16 aProc = a;
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint16_uint8(bytes calldata a, uint8 b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        uint8 bProc = b;
+        euint16 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_uint16_euint8(uint16 a, bytes calldata b) public view returns (uint16) {
+        uint16 aProc = a;
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function add_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function div_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.div(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function rem_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
+        euint8 bProc = TFHE.asEuint8(b);
         euint32 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shl_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
+    function shl_euint32_uint8(bytes calldata a, uint8 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint8 bProc = b;
         euint32 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+    function shl_uint32_euint8(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint8 bProc = TFHE.asEuint8(b);
+        euint32 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
+        euint8 bProc = TFHE.asEuint8(b);
         euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
+    function shr_euint32_uint8(bytes calldata a, uint8 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint8 bProc = b;
         euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function eq_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function eq_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+    function shr_uint32_euint8(uint32 a, bytes calldata b) public view returns (uint32) {
         uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.max(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.max(aProc, bProc);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -4,57 +4,32 @@ pragma solidity 0.8.19;
 
 interface FhevmLib {
     function fheAdd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheSub(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheMul(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheDiv(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheRem(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheBitAnd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheBitOr(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheBitXor(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheShl(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheShr(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheEq(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheNe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheGe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheGt(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheLe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheLt(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheMin(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheMax(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
-
     function fheNeg(uint256 ct) external pure returns (uint256 result);
-
     function fheNot(uint256 ct) external pure returns (uint256 result);
 
     function reencrypt(uint256 ct, uint256 publicKey) external view returns (bytes memory);
-
     function fhePubKey(bytes1 fromLib) external view returns (bytes memory result);
-
     function verifyCiphertext(bytes memory input) external pure returns (uint256 result);
-
     function cast(uint256 ct, bytes1 toType) external pure returns (uint256 result);
-
     function trivialEncrypt(uint256 ct, bytes1 toType) external pure returns (uint256 result);
-
     function decrypt(uint256 ct) external view returns (uint256 result);
-
     function fheRand(bytes1 inp) external view returns (uint256 result);
 }
 

--- a/lib/Impl.sol
+++ b/lib/Impl.sol
@@ -4,32 +4,57 @@ pragma solidity 0.8.19;
 
 interface FhevmLib {
     function fheAdd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheSub(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheMul(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheDiv(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheRem(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheBitAnd(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheBitOr(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheBitXor(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheShl(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheShr(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheEq(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheNe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheGe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheGt(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheLe(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheLt(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheMin(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheMax(uint256 lhs, uint256 rhs, bytes1 scalarByte) external pure returns (uint256 result);
+
     function fheNeg(uint256 ct) external pure returns (uint256 result);
+
     function fheNot(uint256 ct) external pure returns (uint256 result);
 
     function reencrypt(uint256 ct, uint256 publicKey) external view returns (bytes memory);
+
     function fhePubKey(bytes1 fromLib) external view returns (bytes memory result);
+
     function verifyCiphertext(bytes memory input) external pure returns (uint256 result);
+
     function cast(uint256 ct, bytes1 toType) external pure returns (uint256 result);
+
     function trivialEncrypt(uint256 ct, bytes1 toType) external pure returns (uint256 result);
+
     function decrypt(uint256 ct) external view returns (uint256 result);
+
     function fheRand(bytes1 inp) external view returns (uint256 result);
 }
 

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -103,28 +103,6 @@ library TFHE {
         return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint8 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -277,28 +255,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -455,28 +411,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint8 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -628,40 +562,6 @@ library TFHE {
             a = asEuint8(0);
         }
         return euint8.wrap(Impl.rem(euint8.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, uint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(aEnc), euint8.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, uint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -858,28 +758,6 @@ library TFHE {
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b))));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint8 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint8 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint16 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1032,28 +910,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1210,28 +1066,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint16 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1383,40 +1217,6 @@ library TFHE {
             a = asEuint16(0);
         }
         return euint16.wrap(Impl.rem(euint16.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, uint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint16 a, euint16 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(aEnc), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, uint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint16 a, euint16 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(aEnc), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1613,28 +1413,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b))));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint8 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint8 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1787,28 +1565,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b))));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint16 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint16 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1965,28 +1721,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -2140,40 +1874,6 @@ library TFHE {
         return euint32.wrap(Impl.rem(euint32.unwrap(a), uint256(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, uint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint32 a, euint32 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(aEnc), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, uint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint32 a, euint32 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(aEnc), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, uint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -2300,6 +2000,174 @@ library TFHE {
             b = asEuint32(0);
         }
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint8 a, euint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint8 a, uint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint8 a, euint8 b) internal pure returns (euint8) {
+        euint8 aEnc = asEuint8(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(aEnc), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint8 a, euint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint8 a, uint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint8 a, euint8 b) internal pure returns (euint8) {
+        euint8 aEnc = asEuint8(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(aEnc), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint16 a, euint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint16 a, uint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint16 a, euint8 b) internal pure returns (euint16) {
+        euint16 aEnc = asEuint16(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(aEnc), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint16 a, euint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint16 a, uint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint16 a, euint8 b) internal pure returns (euint16) {
+        euint16 aEnc = asEuint16(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(aEnc), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint32 a, euint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint32 a, uint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(uint32 a, euint8 b) internal pure returns (euint32) {
+        euint32 aEnc = asEuint32(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(aEnc), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint32 a, euint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint32 a, uint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(uint32 a, euint8 b) internal pure returns (euint32) {
+        euint32 aEnc = asEuint32(a);
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // If 'control''s value is 'true', the result has the same value as 'a'.

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -2372,7 +2372,7 @@ library TFHE {
     }
 
     function not(ebool a) internal pure returns (ebool) {
-        return asEbool(not(asEuint8(a)));
+        return asEbool(and(not(asEuint8(a)), asEuint8(1)));
     }
 
     // If 'control''s value is 'true', the result has the same value as 'a'.

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -2021,15 +2021,6 @@ library TFHE {
         return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(aEnc), euint8.unwrap(b), false));
-    }
-
     // Evaluate shr(a, b) and return the result.
     function shr(euint8 a, euint8 b) internal pure returns (euint8) {
         if (!isInitialized(a)) {
@@ -2047,15 +2038,6 @@ library TFHE {
             a = asEuint8(0);
         }
         return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // Evaluate shl(a, b) and return the result.
@@ -2077,15 +2059,6 @@ library TFHE {
         return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint16 a, euint8 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(aEnc), euint8.unwrap(b), false));
-    }
-
     // Evaluate shr(a, b) and return the result.
     function shr(euint16 a, euint8 b) internal pure returns (euint16) {
         if (!isInitialized(a)) {
@@ -2103,15 +2076,6 @@ library TFHE {
             a = asEuint16(0);
         }
         return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint16 a, euint8 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // Evaluate shl(a, b) and return the result.
@@ -2133,15 +2097,6 @@ library TFHE {
         return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint32 a, euint8 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(aEnc), euint8.unwrap(b), false));
-    }
-
     // Evaluate shr(a, b) and return the result.
     function shr(euint32 a, euint8 b) internal pure returns (euint32) {
         if (!isInitialized(a)) {
@@ -2159,15 +2114,6 @@ library TFHE {
             a = asEuint32(0);
         }
         return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint32 a, euint8 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // If 'control''s value is 'true', the result has the same value as 'a'.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhevm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhevm",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fhevm",
   "description": "A Solidity library for interacting with the Zama Blockchain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "lib/TFHE.sol",
   "directories": {
     "example": "examples",

--- a/test/tfheOperations/manual.ts
+++ b/test/tfheOperations/manual.ts
@@ -68,6 +68,37 @@ describe('TFHE manual operations', function () {
     expect(res).to.equal(0);
   });
 
+  it('ebool not for false is true', async function () {
+    const res = await this.contract.test_ebool_not(false);
+    expect(res).to.equal(true);
+  });
+
+  it('ebool not for true is false', async function () {
+    const res = await this.contract.test_ebool_not(true);
+    expect(res).to.equal(false);
+  });
+
+  it('ebool and', async function () {
+    expect(await this.contract.test_ebool_and(false, false)).to.equal(false);
+    expect(await this.contract.test_ebool_and(false, true)).to.equal(false);
+    expect(await this.contract.test_ebool_and(true, false)).to.equal(false);
+    expect(await this.contract.test_ebool_and(true, true)).to.equal(true);
+  });
+
+  it('ebool or', async function () {
+    expect(await this.contract.test_ebool_or(false, false)).to.equal(false);
+    expect(await this.contract.test_ebool_or(false, true)).to.equal(true);
+    expect(await this.contract.test_ebool_or(true, false)).to.equal(true);
+    expect(await this.contract.test_ebool_or(true, true)).to.equal(true);
+  });
+
+  it('ebool xor', async function () {
+    expect(await this.contract.test_ebool_xor(false, false)).to.equal(false);
+    expect(await this.contract.test_ebool_xor(false, true)).to.equal(true);
+    expect(await this.contract.test_ebool_xor(true, false)).to.equal(true);
+    expect(await this.contract.test_ebool_xor(true, true)).to.equal(false);
+  });
+
   if (OPTIMISTIC_REQUIRES_ENABLED) {
     it('optimistic require with true succeeds', async function () {
       await this.contract.test_opt_req(true);

--- a/test/tfheOperations/tfheOperations.ts
+++ b/test/tfheOperations/tfheOperations.ts
@@ -120,38 +120,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(46);
   });
 
-  it('test operator "shl" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
-    const res = await this.contract1.shl_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(1),
-    );
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shl" overload (euint8, euint8) => euint8 test 2 (2, 4)', async function () {
-    const res = await this.contract1.shl_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(4),
-    );
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(1),
-    );
-    expect(res).to.equal(1);
-  });
-
-  it('test operator "shr" overload (euint8, euint8) => euint8 test 2 (32, 4)', async function () {
-    const res = await this.contract1.shr_euint8_euint8(
-      this.instances1.alice.encrypt8(32),
-      this.instances1.alice.encrypt8(4),
-    );
-    expect(res).to.equal(2);
-  });
-
   it('test operator "eq" overload (euint8, euint8) => ebool test 1 (12, 49)', async function () {
     const res = await this.contract1.eq_euint8_euint8(
       this.instances1.alice.encrypt8(12),
@@ -398,38 +366,6 @@ describe('TFHE operations', function () {
       this.instances1.alice.encrypt16(65280),
     );
     expect(res).to.equal(65535);
-  });
-
-  it('test operator "shl" overload (euint8, euint16) => euint16 test 1 (255, 256)', async function () {
-    const res = await this.contract1.shl_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(256),
-    );
-    expect(res).to.equal(255);
-  });
-
-  it('test operator "shl" overload (euint8, euint16) => euint16 test 2 (2, 1)', async function () {
-    const res = await this.contract1.shl_euint8_euint16(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt16(1),
-    );
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shr" overload (euint8, euint16) => euint16 test 1 (255, 256)', async function () {
-    const res = await this.contract1.shr_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(256),
-    );
-    expect(res).to.equal(255);
-  });
-
-  it('test operator "shr" overload (euint8, euint16) => euint16 test 2 (255, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(1),
-    );
-    expect(res).to.equal(127);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 1 (255, 255)', async function () {
@@ -688,54 +624,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(65537);
   });
 
-  it('test operator "shl" overload (euint8, euint32) => euint32 test 1 (16, 65536)', async function () {
-    const res = await this.contract1.shl_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(16);
-  });
-
-  it('test operator "shl" overload (euint8, euint32) => euint32 test 2 (31, 65536)', async function () {
-    const res = await this.contract1.shl_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(31);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 1 (16, 65536)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(16);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 2 (31, 65536)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(31);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 3 (16, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(1),
-    );
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 4 (31, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(1),
-    );
-    expect(res).to.equal(15);
-  });
-
   it('test operator "eq" overload (euint8, euint32) => ebool test 1 (1, 1)', async function () {
     const res = await this.contract1.eq_euint8_euint32(
       this.instances1.alice.encrypt8(1),
@@ -980,46 +868,6 @@ describe('TFHE operations', function () {
   it('test operator "rem" overload (euint8, uint8) => euint8 test 1 (8, 3)', async function () {
     const res = await this.contract1.rem_euint8_uint8(this.instances1.alice.encrypt8(8), 3);
     expect(res).to.equal(2);
-  });
-
-  it('test operator "shl" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shl_euint8_uint8(this.instances1.alice.encrypt8(16), 1);
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shl" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shl_euint8_uint8(this.instances1.alice.encrypt8(16), 2);
-    expect(res).to.equal(64);
-  });
-
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shl_uint8_euint8(16, this.instances1.alice.encrypt8(1));
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shl_uint8_euint8(16, this.instances1.alice.encrypt8(2));
-    expect(res).to.equal(64);
-  });
-
-  it('test operator "shr" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shr_euint8_uint8(this.instances1.alice.encrypt8(16), 1);
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shr_euint8_uint8(this.instances1.alice.encrypt8(16), 2);
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shr_uint8_euint8(16, this.instances1.alice.encrypt8(1));
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shr_uint8_euint8(16, this.instances1.alice.encrypt8(2));
-    expect(res).to.equal(4);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 1 (16, 16)', async function () {
@@ -1330,22 +1178,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(4098);
   });
 
-  it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract1.shl_euint16_euint8(
-      this.instances1.alice.encrypt16(4112),
-      this.instances1.alice.encrypt8(2),
-    );
-    expect(res).to.equal(16448);
-  });
-
-  it('test operator "shr" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract1.shr_euint16_euint8(
-      this.instances1.alice.encrypt16(4112),
-      this.instances1.alice.encrypt8(2),
-    );
-    expect(res).to.equal(1028);
-  });
-
   it('test operator "eq" overload (euint16, euint8) => ebool test 1 (16, 16)', async function () {
     const res = await this.contract1.eq_euint16_euint8(
       this.instances1.alice.encrypt16(16),
@@ -1594,292 +1426,260 @@ describe('TFHE operations', function () {
     expect(res).to.equal(514);
   });
 
-  it('test operator "shl" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract1.shl_euint16_euint16(
-      this.instances1.alice.encrypt16(512),
-      this.instances1.alice.encrypt16(2),
-    );
-    expect(res).to.equal(2048);
-  });
-
-  it('test operator "shr" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract1.shr_euint16_euint16(
-      this.instances1.alice.encrypt16(512),
-      this.instances1.alice.encrypt16(2),
-    );
-    expect(res).to.equal(128);
-  });
-
   it('test operator "eq" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.eq_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.eq_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.eq_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.eq_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.ne_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.ne_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.ne_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.ne_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(2);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 2 (512, 512)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 3 (512, 513)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 2 (512, 512)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 3 (512, 513)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(513);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 1 (514, 131074)', async function () {
-    const res = await this.contract2.add_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(131074),
+    const res = await this.contract1.add_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(131074),
     );
     expect(res).to.equal(131588);
   });
 
   it('test operator "sub" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.sub_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
+    const res = await this.contract1.sub_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(2),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "sub" overload (euint16, euint32) => euint32 test 2 (514, 65536)', async function () {
-    const res = await this.contract2.sub_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.sub_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(4294902274);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 1 (512, 65536)', async function () {
-    const res = await this.contract2.mul_euint16_euint32(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.mul_euint16_euint32(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(33554432);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.and_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.and_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(0);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.and_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.and_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(2);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.or_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.or_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.or_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.or_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.xor_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.xor_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.xor_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.xor_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(66048);
-  });
-
-  it('test operator "shl" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.shl_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(2056);
-  });
-
-  it('test operator "shr" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.shr_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(128);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 1 (514, 66050)', async function () {
@@ -2096,26 +1896,6 @@ describe('TFHE operations', function () {
   it('test operator "rem" overload (euint16, uint16) => euint16 test 1 (1544, 3)', async function () {
     const res = await this.contract2.rem_euint16_uint16(this.instances2.alice.encrypt16(1544), 3);
     expect(res).to.equal(2);
-  });
-
-  it('test operator "shl" overload (euint16, uint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shl_euint16_uint16(this.instances2.alice.encrypt16(1542), 3);
-    expect(res).to.equal(12336);
-  });
-
-  it('test operator "shl" overload (uint16, euint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shl_uint16_euint16(1542, this.instances2.alice.encrypt16(3));
-    expect(res).to.equal(12336);
-  });
-
-  it('test operator "shr" overload (euint16, uint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shr_euint16_uint16(this.instances2.alice.encrypt16(1542), 3);
-    expect(res).to.equal(192);
-  });
-
-  it('test operator "shr" overload (uint16, euint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shr_uint16_euint16(1542, this.instances2.alice.encrypt16(3));
-    expect(res).to.equal(192);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 1 (1542, 1542)', async function () {
@@ -2410,22 +2190,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(50397184);
   });
 
-  it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract2.shl_euint32_euint8(
-      this.instances2.alice.encrypt32(50397184),
-      this.instances2.alice.encrypt8(3),
-    );
-    expect(res).to.equal(403177472);
-  });
-
-  it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract2.shr_euint32_euint8(
-      this.instances2.alice.encrypt32(50397184),
-      this.instances2.alice.encrypt8(3),
-    );
-    expect(res).to.equal(6299648);
-  });
-
   it('test operator "eq" overload (euint32, euint8) => ebool test 1 (3, 3)', async function () {
     const res = await this.contract2.eq_euint32_euint8(
       this.instances2.alice.encrypt32(3),
@@ -2664,22 +2428,6 @@ describe('TFHE operations', function () {
       this.instances2.alice.encrypt16(4099),
     );
     expect(res).to.equal(50335776);
-  });
-
-  it('test operator "shl" overload (euint32, euint16) => euint32 test 1 (50331648, 2)', async function () {
-    const res = await this.contract2.shl_euint32_euint16(
-      this.instances2.alice.encrypt32(50331648),
-      this.instances2.alice.encrypt16(2),
-    );
-    expect(res).to.equal(201326592);
-  });
-
-  it('test operator "shr" overload (euint32, euint16) => euint32 test 1 (50331648, 2)', async function () {
-    const res = await this.contract2.shr_euint32_euint16(
-      this.instances2.alice.encrypt32(50331648),
-      this.instances2.alice.encrypt16(2),
-    );
-    expect(res).to.equal(12582912);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 1 (4096, 4096)', async function () {
@@ -2930,22 +2678,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(1412501504);
   });
 
-  it('test operator "shl" overload (euint32, euint32) => euint32 test 1 (3280896, 2)', async function () {
-    const res = await this.contract2.shl_euint32_euint32(
-      this.instances2.alice.encrypt32(3280896),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(13123584);
-  });
-
-  it('test operator "shr" overload (euint32, euint32) => euint32 test 1 (3280896, 2)', async function () {
-    const res = await this.contract2.shr_euint32_euint32(
-      this.instances2.alice.encrypt32(3280896),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(820224);
-  });
-
   it('test operator "eq" overload (euint32, euint32) => ebool test 1 (3280896, 3280896)', async function () {
     const res = await this.contract2.eq_euint32_euint32(
       this.instances2.alice.encrypt32(3280896),
@@ -3123,283 +2855,407 @@ describe('TFHE operations', function () {
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.add_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3280896);
+    const res = await this.contract2.add_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3280896);
     expect(res).to.equal(6696960);
   });
 
   it('test operator "add" overload (uint32, euint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.add_uint32_euint32(3416064, this.instances3.alice.encrypt32(3280896));
+    const res = await this.contract2.add_uint32_euint32(3416064, this.instances2.alice.encrypt32(3280896));
     expect(res).to.equal(6696960);
   });
 
   it('test operator "sub" overload (euint32, uint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.sub_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3280896);
+    const res = await this.contract2.sub_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3280896);
     expect(res).to.equal(135168);
   });
 
   it('test operator "sub" overload (uint32, euint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.sub_uint32_euint32(3416064, this.instances3.alice.encrypt32(3280896));
+    const res = await this.contract2.sub_uint32_euint32(3416064, this.instances2.alice.encrypt32(3280896));
     expect(res).to.equal(135168);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.mul_euint32_uint32(this.instances3.alice.encrypt32(3416064), 256);
+    const res = await this.contract2.mul_euint32_uint32(this.instances2.alice.encrypt32(3416064), 256);
     expect(res).to.equal(874512384);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.mul_uint32_euint32(3416064, this.instances3.alice.encrypt32(256));
+    const res = await this.contract2.mul_uint32_euint32(3416064, this.instances2.alice.encrypt32(256));
     expect(res).to.equal(874512384);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.div_euint32_uint32(this.instances3.alice.encrypt32(3416064), 256);
+    const res = await this.contract2.div_euint32_uint32(this.instances2.alice.encrypt32(3416064), 256);
     expect(res).to.equal(13344);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 1 (3416121, 256)', async function () {
-    const res = await this.contract3.rem_euint32_uint32(this.instances3.alice.encrypt32(3416121), 256);
+    const res = await this.contract2.rem_euint32_uint32(this.instances2.alice.encrypt32(3416121), 256);
     expect(res).to.equal(57);
   });
 
-  it('test operator "shl" overload (euint32, uint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shl_euint32_uint32(this.instances3.alice.encrypt32(3416064), 1);
-    expect(res).to.equal(6832128);
-  });
-
-  it('test operator "shl" overload (uint32, euint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shl_uint32_euint32(3416064, this.instances3.alice.encrypt32(1));
-    expect(res).to.equal(6832128);
-  });
-
-  it('test operator "shr" overload (euint32, uint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shr_euint32_uint32(this.instances3.alice.encrypt32(3416064), 1);
-    expect(res).to.equal(1708032);
-  });
-
-  it('test operator "shr" overload (uint32, euint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shr_uint32_euint32(3416064, this.instances3.alice.encrypt32(1));
-    expect(res).to.equal(1708032);
-  });
-
   it('test operator "eq" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.eq_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.eq_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.eq_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.eq_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.eq_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.eq_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.eq_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.eq_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ne_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.ne_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ne_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.ne_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ne_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.ne_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ne_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.ne_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(false);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(3416063);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(3416063);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(3416065);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(3416065);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(3416064);
+  });
+
+  it('test operator "shl" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
+    const res = await this.contract2.shl_euint8_euint8(
+      this.instances2.alice.encrypt8(2),
+      this.instances2.alice.encrypt8(1),
+    );
+    expect(res).to.equal(4);
+  });
+
+  it('test operator "shl" overload (euint8, euint8) => euint8 test 2 (2, 4)', async function () {
+    const res = await this.contract2.shl_euint8_euint8(
+      this.instances2.alice.encrypt8(2),
+      this.instances2.alice.encrypt8(4),
+    );
+    expect(res).to.equal(32);
+  });
+
+  it('test operator "shl" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract2.shl_euint8_uint8(this.instances2.alice.encrypt8(16), 1);
+    expect(res).to.equal(32);
+  });
+
+  it('test operator "shl" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract2.shl_euint8_uint8(this.instances2.alice.encrypt8(16), 2);
+    expect(res).to.equal(64);
+  });
+
+  it('test operator "shl" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract3.shl_uint8_euint8(16, this.instances3.alice.encrypt8(1));
+    expect(res).to.equal(32);
+  });
+
+  it('test operator "shl" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract3.shl_uint8_euint8(16, this.instances3.alice.encrypt8(2));
+    expect(res).to.equal(64);
+  });
+
+  it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
+    const res = await this.contract3.shr_euint8_euint8(
+      this.instances3.alice.encrypt8(2),
+      this.instances3.alice.encrypt8(1),
+    );
+    expect(res).to.equal(1);
+  });
+
+  it('test operator "shr" overload (euint8, euint8) => euint8 test 2 (32, 4)', async function () {
+    const res = await this.contract3.shr_euint8_euint8(
+      this.instances3.alice.encrypt8(32),
+      this.instances3.alice.encrypt8(4),
+    );
+    expect(res).to.equal(2);
+  });
+
+  it('test operator "shr" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract3.shr_euint8_uint8(this.instances3.alice.encrypt8(16), 1);
+    expect(res).to.equal(8);
+  });
+
+  it('test operator "shr" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract3.shr_euint8_uint8(this.instances3.alice.encrypt8(16), 2);
+    expect(res).to.equal(4);
+  });
+
+  it('test operator "shr" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract3.shr_uint8_euint8(16, this.instances3.alice.encrypt8(1));
+    expect(res).to.equal(8);
+  });
+
+  it('test operator "shr" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract3.shr_uint8_euint8(16, this.instances3.alice.encrypt8(2));
+    expect(res).to.equal(4);
+  });
+
+  it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shl_euint16_euint8(
+      this.instances3.alice.encrypt16(4112),
+      this.instances3.alice.encrypt8(2),
+    );
+    expect(res).to.equal(16448);
+  });
+
+  it('test operator "shl" overload (euint16, uint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shl_euint16_uint8(this.instances3.alice.encrypt16(4112), 2);
+    expect(res).to.equal(16448);
+  });
+
+  it('test operator "shl" overload (uint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shl_uint16_euint8(4112, this.instances3.alice.encrypt8(2));
+    expect(res).to.equal(16448);
+  });
+
+  it('test operator "shr" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shr_euint16_euint8(
+      this.instances3.alice.encrypt16(4112),
+      this.instances3.alice.encrypt8(2),
+    );
+    expect(res).to.equal(1028);
+  });
+
+  it('test operator "shr" overload (euint16, uint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shr_euint16_uint8(this.instances3.alice.encrypt16(4112), 2);
+    expect(res).to.equal(1028);
+  });
+
+  it('test operator "shr" overload (uint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shr_uint16_euint8(4112, this.instances3.alice.encrypt8(2));
+    expect(res).to.equal(1028);
+  });
+
+  it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shl_euint32_euint8(
+      this.instances3.alice.encrypt32(50397184),
+      this.instances3.alice.encrypt8(3),
+    );
+    expect(res).to.equal(403177472);
+  });
+
+  it('test operator "shl" overload (euint32, uint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shl_euint32_uint8(this.instances3.alice.encrypt32(50397184), 3);
+    expect(res).to.equal(403177472);
+  });
+
+  it('test operator "shl" overload (uint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shl_uint32_euint8(50397184, this.instances3.alice.encrypt8(3));
+    expect(res).to.equal(403177472);
+  });
+
+  it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shr_euint32_euint8(
+      this.instances3.alice.encrypt32(50397184),
+      this.instances3.alice.encrypt8(3),
+    );
+    expect(res).to.equal(6299648);
+  });
+
+  it('test operator "shr" overload (euint32, uint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shr_euint32_uint8(this.instances3.alice.encrypt32(50397184), 3);
+    expect(res).to.equal(6299648);
+  });
+
+  it('test operator "shr" overload (uint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shr_uint32_euint8(50397184, this.instances3.alice.encrypt8(3));
+    expect(res).to.equal(6299648);
   });
 
   it('test operator "neg" overload (euint8) => euint8 test 1 (1)', async function () {

--- a/test/tfheOperations/tfheOperations.ts
+++ b/test/tfheOperations/tfheOperations.ts
@@ -3140,16 +3140,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(64);
   });
 
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract3.shl_uint8_euint8(16, this.instances3.alice.encrypt8(1));
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract3.shl_uint8_euint8(16, this.instances3.alice.encrypt8(2));
-    expect(res).to.equal(64);
-  });
-
   it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
     const res = await this.contract3.shr_euint8_euint8(
       this.instances3.alice.encrypt8(2),
@@ -3176,16 +3166,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(4);
   });
 
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract3.shr_uint8_euint8(16, this.instances3.alice.encrypt8(1));
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract3.shr_uint8_euint8(16, this.instances3.alice.encrypt8(2));
-    expect(res).to.equal(4);
-  });
-
   it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
     const res = await this.contract3.shl_euint16_euint8(
       this.instances3.alice.encrypt16(4112),
@@ -3196,11 +3176,6 @@ describe('TFHE operations', function () {
 
   it('test operator "shl" overload (euint16, uint8) => euint16 test 1 (4112, 2)', async function () {
     const res = await this.contract3.shl_euint16_uint8(this.instances3.alice.encrypt16(4112), 2);
-    expect(res).to.equal(16448);
-  });
-
-  it('test operator "shl" overload (uint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract3.shl_uint16_euint8(4112, this.instances3.alice.encrypt8(2));
     expect(res).to.equal(16448);
   });
 
@@ -3217,11 +3192,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(1028);
   });
 
-  it('test operator "shr" overload (uint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract3.shr_uint16_euint8(4112, this.instances3.alice.encrypt8(2));
-    expect(res).to.equal(1028);
-  });
-
   it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
     const res = await this.contract3.shl_euint32_euint8(
       this.instances3.alice.encrypt32(50397184),
@@ -3235,11 +3205,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(403177472);
   });
 
-  it('test operator "shl" overload (uint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract3.shl_uint32_euint8(50397184, this.instances3.alice.encrypt8(3));
-    expect(res).to.equal(403177472);
-  });
-
   it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
     const res = await this.contract3.shr_euint32_euint8(
       this.instances3.alice.encrypt32(50397184),
@@ -3250,11 +3215,6 @@ describe('TFHE operations', function () {
 
   it('test operator "shr" overload (euint32, uint8) => euint32 test 1 (50397184, 3)', async function () {
     const res = await this.contract3.shr_euint32_uint8(this.instances3.alice.encrypt32(50397184), 3);
-    expect(res).to.equal(6299648);
-  });
-
-  it('test operator "shr" overload (uint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract3.shr_uint32_euint8(50397184, this.instances3.alice.encrypt8(3));
     expect(res).to.equal(6299648);
   });
 


### PR DESCRIPTION
there is still some error that I do not understand where it comes from in the case of shift operators with : (uintX,euint8) signature. Codegen works but when running tfheOperations test with hardhat it tells me : 
```
TypeError: Member "shl" not unique after argument-dependent lookup in type(library TFHE).
  --> examples/tests/TFHETestSuite3.sol:10:25:
   |
10 |         euint8 result = TFHE.shl(aProc, bProc);
   |                         ^^^^^^^^
```

Which does not make sens for me since this function is defined only once with the (uint8,euint8) signature inside TFHE.sol

EDIT : this was solved by removing the shl/shr operators with (uintX,euitn8) signatures. Because solidity does not support this type of overloading :  https://forum.soliditylang.org/t/no-unique-declaration-found-when-overloading-functions-with-integers-of-different-sizes/1308 

In conclusion this PR removes the shift operators with a second operand greater than euint8/uint8 types.
By adding a `shiftOperator` key in the two shift operators objects, it implements the following operators : 
`shr(euintX,euint8)`, `shl(euintX,euint8)`, `shr(euintX,uint8)` and `shl(euintX,uint8)`, whenre `X` is `8`, `16` or `32`.