### PR TITLE
made shl and shr more consistent with cleartext shift operators by restraining second operand to 8 bits

### DIFF
--- a/codegen/common.ts
+++ b/codegen/common.ts
@@ -21,6 +21,7 @@ export type Operator = {
   fheLibName?: string;
   binarySolidityOperator?: string;
   unarySolidityOperator?: string;
+  shiftOperator?: boolean;
 };
 
 export type CodegenContext = {
@@ -125,6 +126,7 @@ export const ALL_OPERATORS: Operator[] = [
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
     leftScalarEncrypt: true,
+    shiftOperator: true,
   },
   {
     name: 'shr',
@@ -134,6 +136,7 @@ export const ALL_OPERATORS: Operator[] = [
     arguments: OperatorArguments.Binary,
     returnType: ReturnType.Uint,
     leftScalarEncrypt: true,
+    shiftOperator: true,
   },
   {
     name: 'eq',

--- a/codegen/overloadTests.ts
+++ b/codegen/overloadTests.ts
@@ -121,16 +121,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0xff, 0xffff], output: 0xff00 },
     { inputs: [0xff, 0xff00], output: 0xffff },
   ],
-  shl_euint8_euint16: [
-    // TODO: should shl output 8bit with 16bit be like that?
-    { inputs: [0xff, 0x0100], output: 0xff },
-    { inputs: [0x02, 0x0001], output: 0x04 },
-  ],
-  shr_euint8_euint16: [
-    // TODO: should shr output 8bit with 16bit be like that?
-    { inputs: [0xff, 0x0100], output: 0xff },
-    { inputs: [0xff, 0x0001], output: 0x7f },
-  ],
   eq_euint8_euint16: [
     { inputs: [0xff, 0x00ff], output: true },
     { inputs: [0xff, 0x01ff], output: false },
@@ -186,18 +176,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   xor_euint8_euint32: [
     { inputs: [0x10, 0x00010000], output: 0x00010010 },
     { inputs: [0x11, 0x00010010], output: 0x00010001 },
-  ],
-  shl_euint8_euint32: [
-    // C compiler emits the same
-    { inputs: [0x10, 0x00010000], output: 0x10 },
-    { inputs: [0x1f, 0x00010000], output: 0x1f },
-  ],
-  shr_euint8_euint32: [
-    // C compiler emits the same
-    { inputs: [0x10, 0x00010000], output: 0x10 },
-    { inputs: [0x1f, 0x00010000], output: 0x1f },
-    { inputs: [0x10, 0x00000001], output: 0x8 },
-    { inputs: [0x1f, 0x00000001], output: 0xf },
   ],
   eq_euint8_euint32: [
     { inputs: [0x01, 0x00000001], output: true },
@@ -265,15 +243,7 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10, 0x01], output: 0x20 },
     { inputs: [0x10, 0x02], output: 0x40 },
   ],
-  shl_uint8_euint8: [
-    { inputs: [0x10, 0x01], output: 0x20 },
-    { inputs: [0x10, 0x02], output: 0x40 },
-  ],
   shr_euint8_uint8: [
-    { inputs: [0x10, 0x01], output: 0x08 },
-    { inputs: [0x10, 0x02], output: 0x04 },
-  ],
-  shr_uint8_euint8: [
     { inputs: [0x10, 0x01], output: 0x08 },
     { inputs: [0x10, 0x02], output: 0x04 },
   ],
@@ -375,7 +345,9 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x10f0, 0xf2], output: 0x1002 },
   ],
   shl_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
+  shl_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x4040 }],
   shr_euint16_euint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
+  shr_euint16_uint8: [{ inputs: [0x1010, 0x02], output: 0x0404 }],
   eq_euint16_euint8: [
     { inputs: [0x0010, 0x10], output: true },
     { inputs: [0x0110, 0x10], output: false },
@@ -429,8 +401,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0200, 0x0002], output: 0x0202 },
     { inputs: [0x0210, 0x0012], output: 0x0202 },
   ],
-  shl_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0800 }],
-  shr_euint16_euint16: [{ inputs: [0x0200, 0x0002], output: 0x0080 }],
   eq_euint16_euint16: [
     { inputs: [0x0200, 0x0002], output: false },
     { inputs: [0x0200, 0x0200], output: true },
@@ -487,8 +457,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x0202, 0x00010000], output: 0x00010202 },
     { inputs: [0x0202, 0x00010002], output: 0x00010200 },
   ],
-  shl_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000808 }],
-  shr_euint16_euint32: [{ inputs: [0x0202, 0x00000002], output: 0x00000080 }],
   eq_euint16_euint32: [
     { inputs: [0x0202, 0x00010202], output: false },
     { inputs: [0x0202, 0x00000202], output: true },
@@ -535,10 +503,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint16_euint16: [{ inputs: [0x0202, 0x0003], output: 0x0606 }],
   div_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x0202 }],
   rem_euint16_uint16: [{ inputs: [0x0608, 0x0003], output: 0x0002 }],
-  shl_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
-  shl_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x3030 }],
-  shr_euint16_uint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],
-  shr_uint16_euint16: [{ inputs: [0x0606, 0x0003], output: 0x00c0 }],
   eq_euint16_uint16: [
     { inputs: [0x0606, 0x0606], output: true },
     { inputs: [0x0606, 0x0605], output: false },
@@ -631,7 +595,9 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03010003, 0x03], output: 0x03010000 },
   ],
   shl_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
+  shl_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x18080000 }],
   shr_euint32_euint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
+  shr_euint32_uint8: [{ inputs: [0x03010000, 0x03], output: 0x00602000 }],
   eq_euint32_euint8: [
     { inputs: [0x00000003, 0x03], output: true },
     { inputs: [0x03000003, 0x03], output: false },
@@ -682,8 +648,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x03000023, 0x1003], output: 0x03001023 },
   ],
   xor_euint32_euint16: [{ inputs: [0x03000023, 0x1003], output: 0x03001020 }],
-  shl_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x0c000000 }],
-  shr_euint32_euint16: [{ inputs: [0x03000000, 0x0002], output: 0x00c00000 }],
   eq_euint32_euint16: [
     { inputs: [0x00001000, 0x1000], output: true },
     { inputs: [0x01001000, 0x1000], output: false },
@@ -737,8 +701,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
     { inputs: [0x00321000, 0x54000000], output: 0x54321000 },
     { inputs: [0x00321000, 0x54030000], output: 0x54311000 },
   ],
-  shl_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x00c84000 }],
-  shr_euint32_euint32: [{ inputs: [0x00321000, 0x00000002], output: 0x000c8400 }],
   eq_euint32_euint32: [
     { inputs: [0x00321000, 0x00321000], output: true },
     { inputs: [0x00321000, 0x00321001], output: false },
@@ -785,10 +747,6 @@ export const overloadTests: { [methodName: string]: OverloadTest[] } = {
   mul_uint32_euint32: [{ inputs: [0x00342000, 0x00000100], output: 0x34200000 }],
   div_euint32_uint32: [{ inputs: [0x00342000, 0x00000100], output: 0x00003420 }],
   rem_euint32_uint32: [{ inputs: [0x00342039, 0x00000100], output: 0x00000039 }],
-  shl_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
-  shl_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x00684000 }],
-  shr_euint32_uint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],
-  shr_uint32_euint32: [{ inputs: [0x00342000, 0x00000001], output: 0x001a1000 }],
   eq_euint32_uint32: [
     { inputs: [0x00342000, 0x00342000], output: true },
     { inputs: [0x00342000, 0x00342001], output: false },

--- a/examples/tests/TFHETestSuite1.sol
+++ b/examples/tests/TFHETestSuite1.sol
@@ -46,20 +46,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint8 aProc = TFHE.asEuint8(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -158,20 +144,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint8_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint8 aProc = TFHE.asEuint8(a);
         euint16 bProc = TFHE.asEuint16(b);
@@ -267,20 +239,6 @@ contract TFHETestSuite1 {
         euint8 aProc = TFHE.asEuint8(a);
         euint32 bProc = TFHE.asEuint32(b);
         euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint8_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint8 aProc = TFHE.asEuint8(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -393,34 +351,6 @@ contract TFHETestSuite1 {
         euint8 aProc = TFHE.asEuint8(a);
         uint8 bProc = b;
         euint8 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        uint8 bProc = b;
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
-        euint8 aProc = TFHE.asEuint8(a);
-        uint8 bProc = b;
-        euint8 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint8_euint8(uint8 a, bytes calldata b) public view returns (uint8) {
-        uint8 aProc = a;
-        euint8 bProc = TFHE.asEuint8(b);
-        euint8 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -578,20 +508,6 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -690,17 +606,101 @@ contract TFHETestSuite1 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+    function eq_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
+        ebool result = TFHE.eq(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+    function ne_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        euint16 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint16 bProc = TFHE.asEuint16(b);
+        euint16 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function and_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.and(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function or_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.or(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function xor_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.xor(aProc, bProc);
         return TFHE.decrypt(result);
     }
 }

--- a/examples/tests/TFHETestSuite2.sol
+++ b/examples/tests/TFHETestSuite2.sol
@@ -4,118 +4,6 @@ pragma solidity 0.8.19;
 import "../../lib/TFHE.sol";
 
 contract TFHETestSuite2 {
-    function eq_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (bool) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_euint16_euint16(bytes calldata a, bytes calldata b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.max(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function add_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function and_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.and(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function or_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.or(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function xor_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint16 aProc = TFHE.asEuint16(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint16_euint32(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint16 aProc = TFHE.asEuint16(a);
         euint32 bProc = TFHE.asEuint32(b);
@@ -225,34 +113,6 @@ contract TFHETestSuite2 {
         euint16 aProc = TFHE.asEuint16(a);
         uint16 bProc = b;
         euint16 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint16_uint16(bytes calldata a, uint16 b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        uint16 bProc = b;
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_uint16_euint16(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint16_uint16(bytes calldata a, uint16 b) public view returns (uint16) {
-        euint16 aProc = TFHE.asEuint16(a);
-        uint16 bProc = b;
-        euint16 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_uint16_euint16(uint16 a, bytes calldata b) public view returns (uint16) {
-        uint16 aProc = a;
-        euint16 bProc = TFHE.asEuint16(b);
-        euint16 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -410,20 +270,6 @@ contract TFHETestSuite2 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint8 bProc = TFHE.asEuint8(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint32 aProc = TFHE.asEuint32(a);
         euint8 bProc = TFHE.asEuint8(b);
@@ -519,20 +365,6 @@ contract TFHETestSuite2 {
         euint32 aProc = TFHE.asEuint32(a);
         euint16 bProc = TFHE.asEuint16(b);
         euint32 result = TFHE.xor(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint32_euint16(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint16(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint16 bProc = TFHE.asEuint16(b);
-        euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
@@ -634,20 +466,6 @@ contract TFHETestSuite2 {
         return TFHE.decrypt(result);
     }
 
-    function shl_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shl(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shr_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
     function eq_euint32_euint32(bytes calldata a, bytes calldata b) public view returns (bool) {
         euint32 aProc = TFHE.asEuint32(a);
         euint32 bProc = TFHE.asEuint32(b);
@@ -701,6 +519,188 @@ contract TFHETestSuite2 {
         euint32 aProc = TFHE.asEuint32(a);
         euint32 bProc = TFHE.asEuint32(b);
         euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function add_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.add(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function sub_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.sub(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function mul_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.mul(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function div_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.div(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function rem_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.rem(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function eq_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.eq(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function eq_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.eq(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ne_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ne_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.ne(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function ge_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.ge(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function gt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.gt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function le_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.le(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function lt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        ebool result = TFHE.lt(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function min_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.min(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint32 bProc = b;
+        euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function max_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
+        uint32 aProc = a;
+        euint32 bProc = TFHE.asEuint32(b);
+        euint32 result = TFHE.max(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        uint8 bProc = b;
+        euint8 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 }

--- a/examples/tests/TFHETestSuite3.sol
+++ b/examples/tests/TFHETestSuite3.sol
@@ -4,199 +4,73 @@ pragma solidity 0.8.19;
 import "../../lib/TFHE.sol";
 
 contract TFHETestSuite3 {
-    function add_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+    function shr_euint8_euint8(bytes calldata a, bytes calldata b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint8 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint8_uint8(bytes calldata a, uint8 b) public view returns (uint8) {
+        euint8 aProc = TFHE.asEuint8(a);
+        uint8 bProc = b;
+        euint8 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint16_uint8(bytes calldata a, uint8 b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        uint8 bProc = b;
+        euint16 result = TFHE.shl(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint16_euint8(bytes calldata a, bytes calldata b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        euint8 bProc = TFHE.asEuint8(b);
+        euint16 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shr_euint16_uint8(bytes calldata a, uint8 b) public view returns (uint16) {
+        euint16 aProc = TFHE.asEuint16(a);
+        uint8 bProc = b;
+        euint16 result = TFHE.shr(aProc, bProc);
+        return TFHE.decrypt(result);
+    }
+
+    function shl_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function add_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.add(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function sub_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.sub(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function mul_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.mul(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function div_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.div(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function rem_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.rem(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function shl_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
+        euint8 bProc = TFHE.asEuint8(b);
         euint32 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shl_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
+    function shl_euint32_uint8(bytes calldata a, uint8 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint8 bProc = b;
         euint32 result = TFHE.shl(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
+    function shr_euint32_euint8(bytes calldata a, bytes calldata b) public view returns (uint32) {
         euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
+        euint8 bProc = TFHE.asEuint8(b);
         euint32 result = TFHE.shr(aProc, bProc);
         return TFHE.decrypt(result);
     }
 
-    function shr_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
+    function shr_euint32_uint8(bytes calldata a, uint8 b) public view returns (uint32) {
+        euint32 aProc = TFHE.asEuint32(a);
+        uint8 bProc = b;
         euint32 result = TFHE.shr(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function eq_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function eq_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.eq(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ne_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.ne(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function ge_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.ge(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function gt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.gt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function le_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.le(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_euint32_uint32(bytes calldata a, uint32 b) public view returns (bool) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function lt_uint32_euint32(uint32 a, bytes calldata b) public view returns (bool) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        ebool result = TFHE.lt(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function min_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.min(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_euint32_uint32(bytes calldata a, uint32 b) public view returns (uint32) {
-        euint32 aProc = TFHE.asEuint32(a);
-        uint32 bProc = b;
-        euint32 result = TFHE.max(aProc, bProc);
-        return TFHE.decrypt(result);
-    }
-
-    function max_uint32_euint32(uint32 a, bytes calldata b) public view returns (uint32) {
-        uint32 aProc = a;
-        euint32 bProc = TFHE.asEuint32(b);
-        euint32 result = TFHE.max(aProc, bProc);
         return TFHE.decrypt(result);
     }
 

--- a/lib/TFHE.sol
+++ b/lib/TFHE.sol
@@ -103,28 +103,6 @@ library TFHE {
         return euint8.wrap(Impl.xor(euint8.unwrap(a), euint8.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint8 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -277,28 +255,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.xor(euint16.unwrap(asEuint16(a)), euint16.unwrap(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(asEuint16(a)), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -455,28 +411,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint8 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -628,40 +562,6 @@ library TFHE {
             a = asEuint8(0);
         }
         return euint8.wrap(Impl.rem(euint8.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint8 a, uint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shl(euint8.unwrap(aEnc), euint8.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint8 a, uint8 b) internal pure returns (euint8) {
-        if (!isInitialized(a)) {
-            a = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint8 a, euint8 b) internal pure returns (euint8) {
-        euint8 aEnc = asEuint8(a);
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint8.wrap(Impl.shr(euint8.unwrap(aEnc), euint8.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -858,28 +758,6 @@ library TFHE {
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(asEuint16(b))));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint8 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint8 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint16 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1032,28 +910,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint16.wrap(Impl.xor(euint16.unwrap(a), euint16.unwrap(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1210,28 +1066,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(asEuint32(a)), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(asEuint32(a)), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint16 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1383,40 +1217,6 @@ library TFHE {
             a = asEuint16(0);
         }
         return euint16.wrap(Impl.rem(euint16.unwrap(a), uint256(b)));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint16 a, uint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint16 a, euint16 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shl(euint16.unwrap(aEnc), euint16.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint16 a, uint16 b) internal pure returns (euint16) {
-        if (!isInitialized(a)) {
-            a = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint16 a, euint16 b) internal pure returns (euint16) {
-        euint16 aEnc = asEuint16(a);
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint16.wrap(Impl.shr(euint16.unwrap(aEnc), euint16.unwrap(b), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1613,28 +1413,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b))));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint8 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint8 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint8(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, euint8 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -1787,28 +1565,6 @@ library TFHE {
             b = asEuint16(0);
         }
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(asEuint32(b))));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint16 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint16 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint16(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
     }
 
     // Evaluate eq(a, b) and return the result.
@@ -1965,28 +1721,6 @@ library TFHE {
         return euint32.wrap(Impl.xor(euint32.unwrap(a), euint32.unwrap(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, euint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, euint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -2140,40 +1874,6 @@ library TFHE {
         return euint32.wrap(Impl.rem(euint32.unwrap(a), uint256(b)));
     }
 
-    // Evaluate shl(a, b) and return the result.
-    function shl(euint32 a, uint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shl(a, b) and return the result.
-    function shl(uint32 a, euint32 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shl(euint32.unwrap(aEnc), euint32.unwrap(b), false));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(euint32 a, uint32 b) internal pure returns (euint32) {
-        if (!isInitialized(a)) {
-            a = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
-    }
-
-    // Evaluate shr(a, b) and return the result.
-    function shr(uint32 a, euint32 b) internal pure returns (euint32) {
-        euint32 aEnc = asEuint32(a);
-        if (!isInitialized(b)) {
-            b = asEuint32(0);
-        }
-        return euint32.wrap(Impl.shr(euint32.unwrap(aEnc), euint32.unwrap(b), false));
-    }
-
     // Evaluate eq(a, b) and return the result.
     function eq(euint32 a, uint32 b) internal pure returns (ebool) {
         if (!isInitialized(a)) {
@@ -2300,6 +2000,120 @@ library TFHE {
             b = asEuint32(0);
         }
         return euint32.wrap(Impl.max(euint32.unwrap(b), uint256(a), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint8 a, euint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint8 a, uint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shl(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint8 a, euint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), euint8.unwrap(b), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint8 a, uint8 b) internal pure returns (euint8) {
+        if (!isInitialized(a)) {
+            a = asEuint8(0);
+        }
+        return euint8.wrap(Impl.shr(euint8.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint16 a, euint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint16 a, uint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shl(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint16 a, euint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), euint16.unwrap(asEuint16(b)), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint16 a, uint8 b) internal pure returns (euint16) {
+        if (!isInitialized(a)) {
+            a = asEuint16(0);
+        }
+        return euint16.wrap(Impl.shr(euint16.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint32 a, euint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
+    }
+
+    // Evaluate shl(a, b) and return the result.
+    function shl(euint32 a, uint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shl(euint32.unwrap(a), uint256(b), true));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint32 a, euint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        if (!isInitialized(b)) {
+            b = asEuint8(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), euint32.unwrap(asEuint32(b)), false));
+    }
+
+    // Evaluate shr(a, b) and return the result.
+    function shr(euint32 a, uint8 b) internal pure returns (euint32) {
+        if (!isInitialized(a)) {
+            a = asEuint32(0);
+        }
+        return euint32.wrap(Impl.shr(euint32.unwrap(a), uint256(b), true));
     }
 
     // If 'control''s value is 'true', the result has the same value as 'a'.

--- a/test/tfheOperations/tfheOperations.ts
+++ b/test/tfheOperations/tfheOperations.ts
@@ -120,38 +120,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(46);
   });
 
-  it('test operator "shl" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
-    const res = await this.contract1.shl_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(1),
-    );
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shl" overload (euint8, euint8) => euint8 test 2 (2, 4)', async function () {
-    const res = await this.contract1.shl_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(4),
-    );
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint8(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt8(1),
-    );
-    expect(res).to.equal(1);
-  });
-
-  it('test operator "shr" overload (euint8, euint8) => euint8 test 2 (32, 4)', async function () {
-    const res = await this.contract1.shr_euint8_euint8(
-      this.instances1.alice.encrypt8(32),
-      this.instances1.alice.encrypt8(4),
-    );
-    expect(res).to.equal(2);
-  });
-
   it('test operator "eq" overload (euint8, euint8) => ebool test 1 (12, 49)', async function () {
     const res = await this.contract1.eq_euint8_euint8(
       this.instances1.alice.encrypt8(12),
@@ -398,38 +366,6 @@ describe('TFHE operations', function () {
       this.instances1.alice.encrypt16(65280),
     );
     expect(res).to.equal(65535);
-  });
-
-  it('test operator "shl" overload (euint8, euint16) => euint16 test 1 (255, 256)', async function () {
-    const res = await this.contract1.shl_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(256),
-    );
-    expect(res).to.equal(255);
-  });
-
-  it('test operator "shl" overload (euint8, euint16) => euint16 test 2 (2, 1)', async function () {
-    const res = await this.contract1.shl_euint8_euint16(
-      this.instances1.alice.encrypt8(2),
-      this.instances1.alice.encrypt16(1),
-    );
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shr" overload (euint8, euint16) => euint16 test 1 (255, 256)', async function () {
-    const res = await this.contract1.shr_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(256),
-    );
-    expect(res).to.equal(255);
-  });
-
-  it('test operator "shr" overload (euint8, euint16) => euint16 test 2 (255, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint16(
-      this.instances1.alice.encrypt8(255),
-      this.instances1.alice.encrypt16(1),
-    );
-    expect(res).to.equal(127);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 1 (255, 255)', async function () {
@@ -688,54 +624,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(65537);
   });
 
-  it('test operator "shl" overload (euint8, euint32) => euint32 test 1 (16, 65536)', async function () {
-    const res = await this.contract1.shl_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(16);
-  });
-
-  it('test operator "shl" overload (euint8, euint32) => euint32 test 2 (31, 65536)', async function () {
-    const res = await this.contract1.shl_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(31);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 1 (16, 65536)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(16);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 2 (31, 65536)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(65536),
-    );
-    expect(res).to.equal(31);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 3 (16, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(16),
-      this.instances1.alice.encrypt32(1),
-    );
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (euint8, euint32) => euint32 test 4 (31, 1)', async function () {
-    const res = await this.contract1.shr_euint8_euint32(
-      this.instances1.alice.encrypt8(31),
-      this.instances1.alice.encrypt32(1),
-    );
-    expect(res).to.equal(15);
-  });
-
   it('test operator "eq" overload (euint8, euint32) => ebool test 1 (1, 1)', async function () {
     const res = await this.contract1.eq_euint8_euint32(
       this.instances1.alice.encrypt8(1),
@@ -980,46 +868,6 @@ describe('TFHE operations', function () {
   it('test operator "rem" overload (euint8, uint8) => euint8 test 1 (8, 3)', async function () {
     const res = await this.contract1.rem_euint8_uint8(this.instances1.alice.encrypt8(8), 3);
     expect(res).to.equal(2);
-  });
-
-  it('test operator "shl" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shl_euint8_uint8(this.instances1.alice.encrypt8(16), 1);
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shl" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shl_euint8_uint8(this.instances1.alice.encrypt8(16), 2);
-    expect(res).to.equal(64);
-  });
-
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shl_uint8_euint8(16, this.instances1.alice.encrypt8(1));
-    expect(res).to.equal(32);
-  });
-
-  it('test operator "shl" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shl_uint8_euint8(16, this.instances1.alice.encrypt8(2));
-    expect(res).to.equal(64);
-  });
-
-  it('test operator "shr" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shr_euint8_uint8(this.instances1.alice.encrypt8(16), 1);
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shr_euint8_uint8(this.instances1.alice.encrypt8(16), 2);
-    expect(res).to.equal(4);
-  });
-
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 1 (16, 1)', async function () {
-    const res = await this.contract1.shr_uint8_euint8(16, this.instances1.alice.encrypt8(1));
-    expect(res).to.equal(8);
-  });
-
-  it('test operator "shr" overload (uint8, euint8) => euint8 test 2 (16, 2)', async function () {
-    const res = await this.contract1.shr_uint8_euint8(16, this.instances1.alice.encrypt8(2));
-    expect(res).to.equal(4);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 1 (16, 16)', async function () {
@@ -1330,22 +1178,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(4098);
   });
 
-  it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract1.shl_euint16_euint8(
-      this.instances1.alice.encrypt16(4112),
-      this.instances1.alice.encrypt8(2),
-    );
-    expect(res).to.equal(16448);
-  });
-
-  it('test operator "shr" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
-    const res = await this.contract1.shr_euint16_euint8(
-      this.instances1.alice.encrypt16(4112),
-      this.instances1.alice.encrypt8(2),
-    );
-    expect(res).to.equal(1028);
-  });
-
   it('test operator "eq" overload (euint16, euint8) => ebool test 1 (16, 16)', async function () {
     const res = await this.contract1.eq_euint16_euint8(
       this.instances1.alice.encrypt16(16),
@@ -1594,292 +1426,260 @@ describe('TFHE operations', function () {
     expect(res).to.equal(514);
   });
 
-  it('test operator "shl" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract1.shl_euint16_euint16(
-      this.instances1.alice.encrypt16(512),
-      this.instances1.alice.encrypt16(2),
-    );
-    expect(res).to.equal(2048);
-  });
-
-  it('test operator "shr" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract1.shr_euint16_euint16(
-      this.instances1.alice.encrypt16(512),
-      this.instances1.alice.encrypt16(2),
-    );
-    expect(res).to.equal(128);
-  });
-
   it('test operator "eq" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.eq_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.eq_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.eq_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.eq_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.ne_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.ne_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.ne_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.ne_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.ge_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.ge_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.gt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.gt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.le_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.le_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 1 (512, 2)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 2 (512, 512)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 3 (512, 513)', async function () {
-    const res = await this.contract2.lt_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.lt_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(true);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(2);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 2 (512, 512)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 3 (512, 513)', async function () {
-    const res = await this.contract2.min_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.min_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 1 (512, 2)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(2),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(2),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 2 (512, 512)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(512),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(512),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 3 (512, 513)', async function () {
-    const res = await this.contract2.max_euint16_euint16(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt16(513),
+    const res = await this.contract1.max_euint16_euint16(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt16(513),
     );
     expect(res).to.equal(513);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 1 (514, 131074)', async function () {
-    const res = await this.contract2.add_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(131074),
+    const res = await this.contract1.add_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(131074),
     );
     expect(res).to.equal(131588);
   });
 
   it('test operator "sub" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.sub_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
+    const res = await this.contract1.sub_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(2),
     );
     expect(res).to.equal(512);
   });
 
   it('test operator "sub" overload (euint16, euint32) => euint32 test 2 (514, 65536)', async function () {
-    const res = await this.contract2.sub_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.sub_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(4294902274);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 1 (512, 65536)', async function () {
-    const res = await this.contract2.mul_euint16_euint32(
-      this.instances2.alice.encrypt16(512),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.mul_euint16_euint32(
+      this.instances1.alice.encrypt16(512),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(33554432);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.and_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.and_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(0);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.and_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.and_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(2);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.or_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.or_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.or_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.or_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 1 (514, 65536)', async function () {
-    const res = await this.contract2.xor_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65536),
+    const res = await this.contract1.xor_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65536),
     );
     expect(res).to.equal(66050);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 2 (514, 65538)', async function () {
-    const res = await this.contract2.xor_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(65538),
+    const res = await this.contract1.xor_euint16_euint32(
+      this.instances1.alice.encrypt16(514),
+      this.instances1.alice.encrypt32(65538),
     );
     expect(res).to.equal(66048);
-  });
-
-  it('test operator "shl" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.shl_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(2056);
-  });
-
-  it('test operator "shr" overload (euint16, euint32) => euint32 test 1 (514, 2)', async function () {
-    const res = await this.contract2.shr_euint16_euint32(
-      this.instances2.alice.encrypt16(514),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(128);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 1 (514, 66050)', async function () {
@@ -2096,26 +1896,6 @@ describe('TFHE operations', function () {
   it('test operator "rem" overload (euint16, uint16) => euint16 test 1 (1544, 3)', async function () {
     const res = await this.contract2.rem_euint16_uint16(this.instances2.alice.encrypt16(1544), 3);
     expect(res).to.equal(2);
-  });
-
-  it('test operator "shl" overload (euint16, uint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shl_euint16_uint16(this.instances2.alice.encrypt16(1542), 3);
-    expect(res).to.equal(12336);
-  });
-
-  it('test operator "shl" overload (uint16, euint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shl_uint16_euint16(1542, this.instances2.alice.encrypt16(3));
-    expect(res).to.equal(12336);
-  });
-
-  it('test operator "shr" overload (euint16, uint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shr_euint16_uint16(this.instances2.alice.encrypt16(1542), 3);
-    expect(res).to.equal(192);
-  });
-
-  it('test operator "shr" overload (uint16, euint16) => euint16 test 1 (1542, 3)', async function () {
-    const res = await this.contract2.shr_uint16_euint16(1542, this.instances2.alice.encrypt16(3));
-    expect(res).to.equal(192);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 1 (1542, 1542)', async function () {
@@ -2410,22 +2190,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(50397184);
   });
 
-  it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract2.shl_euint32_euint8(
-      this.instances2.alice.encrypt32(50397184),
-      this.instances2.alice.encrypt8(3),
-    );
-    expect(res).to.equal(403177472);
-  });
-
-  it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
-    const res = await this.contract2.shr_euint32_euint8(
-      this.instances2.alice.encrypt32(50397184),
-      this.instances2.alice.encrypt8(3),
-    );
-    expect(res).to.equal(6299648);
-  });
-
   it('test operator "eq" overload (euint32, euint8) => ebool test 1 (3, 3)', async function () {
     const res = await this.contract2.eq_euint32_euint8(
       this.instances2.alice.encrypt32(3),
@@ -2664,22 +2428,6 @@ describe('TFHE operations', function () {
       this.instances2.alice.encrypt16(4099),
     );
     expect(res).to.equal(50335776);
-  });
-
-  it('test operator "shl" overload (euint32, euint16) => euint32 test 1 (50331648, 2)', async function () {
-    const res = await this.contract2.shl_euint32_euint16(
-      this.instances2.alice.encrypt32(50331648),
-      this.instances2.alice.encrypt16(2),
-    );
-    expect(res).to.equal(201326592);
-  });
-
-  it('test operator "shr" overload (euint32, euint16) => euint32 test 1 (50331648, 2)', async function () {
-    const res = await this.contract2.shr_euint32_euint16(
-      this.instances2.alice.encrypt32(50331648),
-      this.instances2.alice.encrypt16(2),
-    );
-    expect(res).to.equal(12582912);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 1 (4096, 4096)', async function () {
@@ -2930,22 +2678,6 @@ describe('TFHE operations', function () {
     expect(res).to.equal(1412501504);
   });
 
-  it('test operator "shl" overload (euint32, euint32) => euint32 test 1 (3280896, 2)', async function () {
-    const res = await this.contract2.shl_euint32_euint32(
-      this.instances2.alice.encrypt32(3280896),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(13123584);
-  });
-
-  it('test operator "shr" overload (euint32, euint32) => euint32 test 1 (3280896, 2)', async function () {
-    const res = await this.contract2.shr_euint32_euint32(
-      this.instances2.alice.encrypt32(3280896),
-      this.instances2.alice.encrypt32(2),
-    );
-    expect(res).to.equal(820224);
-  });
-
   it('test operator "eq" overload (euint32, euint32) => ebool test 1 (3280896, 3280896)', async function () {
     const res = await this.contract2.eq_euint32_euint32(
       this.instances2.alice.encrypt32(3280896),
@@ -3123,283 +2855,367 @@ describe('TFHE operations', function () {
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.add_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3280896);
+    const res = await this.contract2.add_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3280896);
     expect(res).to.equal(6696960);
   });
 
   it('test operator "add" overload (uint32, euint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.add_uint32_euint32(3416064, this.instances3.alice.encrypt32(3280896));
+    const res = await this.contract2.add_uint32_euint32(3416064, this.instances2.alice.encrypt32(3280896));
     expect(res).to.equal(6696960);
   });
 
   it('test operator "sub" overload (euint32, uint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.sub_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3280896);
+    const res = await this.contract2.sub_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3280896);
     expect(res).to.equal(135168);
   });
 
   it('test operator "sub" overload (uint32, euint32) => euint32 test 1 (3416064, 3280896)', async function () {
-    const res = await this.contract3.sub_uint32_euint32(3416064, this.instances3.alice.encrypt32(3280896));
+    const res = await this.contract2.sub_uint32_euint32(3416064, this.instances2.alice.encrypt32(3280896));
     expect(res).to.equal(135168);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.mul_euint32_uint32(this.instances3.alice.encrypt32(3416064), 256);
+    const res = await this.contract2.mul_euint32_uint32(this.instances2.alice.encrypt32(3416064), 256);
     expect(res).to.equal(874512384);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.mul_uint32_euint32(3416064, this.instances3.alice.encrypt32(256));
+    const res = await this.contract2.mul_uint32_euint32(3416064, this.instances2.alice.encrypt32(256));
     expect(res).to.equal(874512384);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 1 (3416064, 256)', async function () {
-    const res = await this.contract3.div_euint32_uint32(this.instances3.alice.encrypt32(3416064), 256);
+    const res = await this.contract2.div_euint32_uint32(this.instances2.alice.encrypt32(3416064), 256);
     expect(res).to.equal(13344);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 1 (3416121, 256)', async function () {
-    const res = await this.contract3.rem_euint32_uint32(this.instances3.alice.encrypt32(3416121), 256);
+    const res = await this.contract2.rem_euint32_uint32(this.instances2.alice.encrypt32(3416121), 256);
     expect(res).to.equal(57);
   });
 
-  it('test operator "shl" overload (euint32, uint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shl_euint32_uint32(this.instances3.alice.encrypt32(3416064), 1);
-    expect(res).to.equal(6832128);
-  });
-
-  it('test operator "shl" overload (uint32, euint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shl_uint32_euint32(3416064, this.instances3.alice.encrypt32(1));
-    expect(res).to.equal(6832128);
-  });
-
-  it('test operator "shr" overload (euint32, uint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shr_euint32_uint32(this.instances3.alice.encrypt32(3416064), 1);
-    expect(res).to.equal(1708032);
-  });
-
-  it('test operator "shr" overload (uint32, euint32) => euint32 test 1 (3416064, 1)', async function () {
-    const res = await this.contract3.shr_uint32_euint32(3416064, this.instances3.alice.encrypt32(1));
-    expect(res).to.equal(1708032);
-  });
-
   it('test operator "eq" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.eq_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.eq_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.eq_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.eq_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.eq_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.eq_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.eq_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.eq_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ne_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.ne_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ne_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.ne_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ne_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.ne_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ne_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.ne_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.ge_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.ge_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.ge_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.ge_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.gt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.gt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(true);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(false);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.gt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.gt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.le_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.le_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(false);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.le_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.le_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.lt_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.lt_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(false);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(true);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.lt_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.lt_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(false);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.min_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.min_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(3416063);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.min_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.min_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(3416063);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416064);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416064);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416065);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416065);
     expect(res).to.equal(3416065);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.max_euint32_uint32(this.instances3.alice.encrypt32(3416064), 3416063);
+    const res = await this.contract2.max_euint32_uint32(this.instances2.alice.encrypt32(3416064), 3416063);
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 1 (3416064, 3416064)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416064));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416064));
     expect(res).to.equal(3416064);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 2 (3416064, 3416065)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416065));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416065));
     expect(res).to.equal(3416065);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 3 (3416064, 3416063)', async function () {
-    const res = await this.contract3.max_uint32_euint32(3416064, this.instances3.alice.encrypt32(3416063));
+    const res = await this.contract2.max_uint32_euint32(3416064, this.instances2.alice.encrypt32(3416063));
     expect(res).to.equal(3416064);
+  });
+
+  it('test operator "shl" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
+    const res = await this.contract2.shl_euint8_euint8(
+      this.instances2.alice.encrypt8(2),
+      this.instances2.alice.encrypt8(1),
+    );
+    expect(res).to.equal(4);
+  });
+
+  it('test operator "shl" overload (euint8, euint8) => euint8 test 2 (2, 4)', async function () {
+    const res = await this.contract2.shl_euint8_euint8(
+      this.instances2.alice.encrypt8(2),
+      this.instances2.alice.encrypt8(4),
+    );
+    expect(res).to.equal(32);
+  });
+
+  it('test operator "shl" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract2.shl_euint8_uint8(this.instances2.alice.encrypt8(16), 1);
+    expect(res).to.equal(32);
+  });
+
+  it('test operator "shl" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract2.shl_euint8_uint8(this.instances2.alice.encrypt8(16), 2);
+    expect(res).to.equal(64);
+  });
+
+  it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (2, 1)', async function () {
+    const res = await this.contract3.shr_euint8_euint8(
+      this.instances3.alice.encrypt8(2),
+      this.instances3.alice.encrypt8(1),
+    );
+    expect(res).to.equal(1);
+  });
+
+  it('test operator "shr" overload (euint8, euint8) => euint8 test 2 (32, 4)', async function () {
+    const res = await this.contract3.shr_euint8_euint8(
+      this.instances3.alice.encrypt8(32),
+      this.instances3.alice.encrypt8(4),
+    );
+    expect(res).to.equal(2);
+  });
+
+  it('test operator "shr" overload (euint8, uint8) => euint8 test 1 (16, 1)', async function () {
+    const res = await this.contract3.shr_euint8_uint8(this.instances3.alice.encrypt8(16), 1);
+    expect(res).to.equal(8);
+  });
+
+  it('test operator "shr" overload (euint8, uint8) => euint8 test 2 (16, 2)', async function () {
+    const res = await this.contract3.shr_euint8_uint8(this.instances3.alice.encrypt8(16), 2);
+    expect(res).to.equal(4);
+  });
+
+  it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shl_euint16_euint8(
+      this.instances3.alice.encrypt16(4112),
+      this.instances3.alice.encrypt8(2),
+    );
+    expect(res).to.equal(16448);
+  });
+
+  it('test operator "shl" overload (euint16, uint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shl_euint16_uint8(this.instances3.alice.encrypt16(4112), 2);
+    expect(res).to.equal(16448);
+  });
+
+  it('test operator "shr" overload (euint16, euint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shr_euint16_euint8(
+      this.instances3.alice.encrypt16(4112),
+      this.instances3.alice.encrypt8(2),
+    );
+    expect(res).to.equal(1028);
+  });
+
+  it('test operator "shr" overload (euint16, uint8) => euint16 test 1 (4112, 2)', async function () {
+    const res = await this.contract3.shr_euint16_uint8(this.instances3.alice.encrypt16(4112), 2);
+    expect(res).to.equal(1028);
+  });
+
+  it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shl_euint32_euint8(
+      this.instances3.alice.encrypt32(50397184),
+      this.instances3.alice.encrypt8(3),
+    );
+    expect(res).to.equal(403177472);
+  });
+
+  it('test operator "shl" overload (euint32, uint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shl_euint32_uint8(this.instances3.alice.encrypt32(50397184), 3);
+    expect(res).to.equal(403177472);
+  });
+
+  it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shr_euint32_euint8(
+      this.instances3.alice.encrypt32(50397184),
+      this.instances3.alice.encrypt8(3),
+    );
+    expect(res).to.equal(6299648);
+  });
+
+  it('test operator "shr" overload (euint32, uint8) => euint32 test 1 (50397184, 3)', async function () {
+    const res = await this.contract3.shr_euint32_uint8(this.instances3.alice.encrypt32(50397184), 3);
+    expect(res).to.equal(6299648);
   });
 
   it('test operator "neg" overload (euint8) => euint8 test 1 (1)', async function () {


### PR DESCRIPTION
The new TFHE.shl and TFHE.shr operators have the following signatures : 
(euintX,euint8)
(euintX,uint8)
With X = 8, 16 or 32