### PR TITLE
Added Reencrypt abstract contract to replace use of EIP712WithModifier

### DIFF
--- a/abstracts/Reencrypt.sol
+++ b/abstracts/Reencrypt.sol
@@ -5,11 +5,8 @@ pragma solidity 0.8.19;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
-/**
- * @dev {EIP712WithModifier} is deprecated. Please use {Reencrypt} instead.
- */
-abstract contract EIP712WithModifier is EIP712 {
-    constructor(string memory name, string memory version) EIP712(name, version) {}
+abstract contract Reencrypt is EIP712 {
+    constructor() EIP712("Authorization token", "1") {}
 
     modifier onlySignedPublicKey(bytes32 publicKey, bytes memory signature) {
         bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(keccak256("Reencrypt(bytes32 publicKey)"), publicKey)));

--- a/docs/howto/decrypt.md
+++ b/docs/howto/decrypt.md
@@ -48,18 +48,14 @@ function balanceOf(bytes32 publicKey) public view returns (bytes memory) {
 In the example above (`balanceOf`), this view function need to validate the user to prevent anyone to reencrypt any user's balance. To prevent this, the user provides a signature of the given public key. The best way to do it is to use [EIP-712 standard](https://eips.ethereum.org/EIPS/eip-712). Since this is something very useful, fhEVM library provide an abstract to use in your contract:
 
 ```solidity
-import "fhevm/abstracts/EIP712WithModifier.sol";
+import "fhevm/abstracts/Reencrypt.sol";
 
-contract EncryptedERC20 is EIP712WithModifier {
-  ...
-  constructor() EIP712WithModifier("Authorization token", "1") {
-    contractOwner = msg.sender;
-  }
+contract EncryptedERC20 is Reencrypt {
   ...
 }
 ```
 
-When a contract uses `EIP712WithModifier` abstract, a modifier is available to check user signature.
+When a contract uses `Reencrypt` abstract, a modifier is available to check user signature.
 
 ```solidity
 function balanceOf(

--- a/examples/BlindAuction.sol
+++ b/examples/BlindAuction.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.19;
 
 import "../lib/TFHE.sol";
 
-import "../abstracts/EIP712WithModifier.sol";
+import "../abstracts/Reencrypt.sol";
 
 import "./EncryptedERC20.sol";
 
-contract BlindAuction is EIP712WithModifier {
+contract BlindAuction is Reencrypt {
     uint public endTime;
 
     address public beneficiary;
@@ -47,12 +47,7 @@ contract BlindAuction is EIP712WithModifier {
 
     event Winner(address who);
 
-    constructor(
-        address _beneficiary,
-        EncryptedERC20 _tokenContract,
-        uint biddingTime,
-        bool isStoppable
-    ) EIP712WithModifier("Authorization token", "1") {
+    constructor(address _beneficiary, EncryptedERC20 _tokenContract, uint biddingTime, bool isStoppable) {
         beneficiary = _beneficiary;
         tokenContract = _tokenContract;
         endTime = block.timestamp + biddingTime;

--- a/examples/CMUX.sol
+++ b/examples/CMUX.sol
@@ -2,14 +2,14 @@
 
 pragma solidity 0.8.19;
 
-import "../abstracts/EIP712WithModifier.sol";
+import "../abstracts/Reencrypt.sol";
 import "../lib/TFHE.sol";
 
 // Shows the CMUX operation in Solidity.
-contract CMUX is EIP712WithModifier {
+contract CMUX is Reencrypt {
     euint8 internal result;
 
-    constructor() EIP712WithModifier("Authorization token", "1") {}
+    constructor() {}
 
     // Set result = if control { ifTrue } else { ifFalse }
     function cmux(bytes calldata controlBytes, bytes calldata ifTrueBytes, bytes calldata ifFalseBytes) public {

--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -2,11 +2,11 @@
 
 pragma solidity 0.8.19;
 
-import "../abstracts/EIP712WithModifier.sol";
+import "../abstracts/Reencrypt.sol";
 
 import "../lib/TFHE.sol";
 
-contract EncryptedERC20 is EIP712WithModifier {
+contract EncryptedERC20 is Reencrypt {
     euint32 private totalSupply;
     string public constant name = "Naraggara"; // City of Zama's battle
     string public constant symbol = "NARA";
@@ -29,7 +29,7 @@ contract EncryptedERC20 is EIP712WithModifier {
     euint8 internal NO_ERROR;
     euint8 internal NOT_ENOUGH_FUND;
 
-    constructor() EIP712WithModifier("Authorization token", "1") {
+    constructor() {
         contractOwner = msg.sender;
         NO_ERROR = TFHE.asEuint8(0);
         NOT_ENOUGH_FUND = TFHE.asEuint8(1);

--- a/examples/Governor/Comp.sol
+++ b/examples/Governor/Comp.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.19;
 
-import "../../abstracts/EIP712WithModifier.sol";
+import "../../abstracts/Reencrypt.sol";
 
 import "../../lib/TFHE.sol";
 
-contract Comp is EIP712WithModifier {
+contract Comp is Reencrypt {
     /// @notice EIP-20 token name for this token
     string public constant name = "Compound";
 
@@ -72,7 +72,7 @@ contract Comp is EIP712WithModifier {
      * @notice Construct a new Comp token
      * @param account The initial account to grant all the tokens
      */
-    constructor(address account) EIP712WithModifier("Authorization token", "1") {
+    constructor(address account) {
         contractOwner = account;
         balances[contractOwner] = totalSupply;
     }

--- a/examples/Identity/AbstractCompliantERC20.sol
+++ b/examples/Identity/AbstractCompliantERC20.sol
@@ -2,16 +2,16 @@
 
 pragma solidity 0.8.19;
 
-import "../../abstracts/EIP712WithModifier.sol";
+import "../../abstracts/Reencrypt.sol";
 import "./ERC20Rules.sol";
 import "./IdentityRegistry.sol";
 
-abstract contract AbstractCompliantERC20 is EIP712WithModifier {
+abstract contract AbstractCompliantERC20 is Reencrypt {
     IdentityRegistry identityContract;
     ERC20Rules rulesContract;
     mapping(address => euint32) internal balances;
 
-    constructor(address _identityAddr, address _rulesAddr) EIP712WithModifier("Authorization token", "1") {
+    constructor(address _identityAddr, address _rulesAddr) {
         identityContract = IdentityRegistry(_identityAddr);
         rulesContract = ERC20Rules(_rulesAddr);
     }

--- a/examples/Identity/IdentityRegistry.sol
+++ b/examples/Identity/IdentityRegistry.sol
@@ -6,11 +6,11 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
-import "../../abstracts/EIP712WithModifier.sol";
+import "../../abstracts/Reencrypt.sol";
 
 import "../../lib/TFHE.sol";
 
-contract IdentityRegistry is EIP712WithModifier, Ownable {
+contract IdentityRegistry is Reencrypt, Ownable {
     // A mapping from wallet to registrarId
     mapping(address => uint) public registrars;
 
@@ -28,7 +28,7 @@ contract IdentityRegistry is EIP712WithModifier, Ownable {
     event NewDid(address wallet);
     event RemoveDid(address wallet);
 
-    constructor() Ownable() EIP712WithModifier("Authorization token", "1") {
+    constructor() Ownable() {
         _transferOwnership(msg.sender);
     }
 


### PR DESCRIPTION
Added `Reencrypt` in `abstracts/`and replaced `EIP712WithModifier` with this new contract in the examples contracts, and updated the documentation to reflect this change, as well as added a deprecation warning comment inside `EIP712WithModifier` abstract contract.