### PR TITLE
Added name and symbol parameters in constructor of EncryptedERC20 and CompliantERC20

### DIFF
--- a/examples/EncryptedERC20.sol
+++ b/examples/EncryptedERC20.sol
@@ -12,8 +12,8 @@ contract EncryptedERC20 is Reencrypt, Ownable2Step {
     event Mint(address indexed to, uint32 amount);
 
     uint32 public totalSupply;
-    string public constant name = "Naraggara"; // City of Zama's battle
-    string public constant symbol = "NARA";
+    string private _name;
+    string private _symbol;
     uint8 public constant decimals = 0;
 
     // A mapping from address to an encrypted balance.
@@ -22,7 +22,20 @@ contract EncryptedERC20 is Reencrypt, Ownable2Step {
     // A mapping of the form mapping(owner => mapping(spender => allowance)).
     mapping(address => mapping(address => euint32)) internal allowances;
 
-    constructor() Ownable(msg.sender) {}
+    constructor(string memory name_, string memory symbol_) Ownable(msg.sender) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    // Returns the name of the token.
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    // Returns the symbol of the token, usually a shorter version of the name.
+    function symbol() public view virtual returns (string memory) {
+        return _symbol;
+    }
 
     // Sets the balance of the owner to the given encrypted balance.
     function mint(uint32 mintedAmount) public onlyOwner {

--- a/examples/Identity/CompliantERC20.sol
+++ b/examples/Identity/CompliantERC20.sol
@@ -12,7 +12,12 @@ contract CompliantERC20 is EncryptedERC20 {
     IdentityRegistry identityContract;
     ERC20Rules rulesContract;
 
-    constructor(address _identityAddr, address _rulesAddr) {
+    constructor(
+        address _identityAddr,
+        address _rulesAddr,
+        string memory _name,
+        string memory _symbol
+    ) EncryptedERC20(_name, _symbol) {
         identityContract = IdentityRegistry(_identityAddr);
         rulesContract = ERC20Rules(_rulesAddr);
     }

--- a/test/encryptedERC20/EncryptedERC20.fixture.ts
+++ b/test/encryptedERC20/EncryptedERC20.fixture.ts
@@ -7,7 +7,7 @@ export async function deployEncryptedERC20Fixture(): Promise<EncryptedERC20> {
   const signers = await getSigners();
 
   const contractFactory = await ethers.getContractFactory('EncryptedERC20');
-  const contract = await contractFactory.connect(signers.alice).deploy();
+  const contract = await contractFactory.connect(signers.alice).deploy('Naraggara', 'NARA'); // City of Zama's battle
   await contract.waitForDeployment();
 
   return contract;

--- a/test/identity/compliantERC20.fixture.ts
+++ b/test/identity/compliantERC20.fixture.ts
@@ -10,7 +10,9 @@ export async function deployCompliantERC20Fixture(
   const signers = await getSigners();
 
   const contractFactory = await ethers.getContractFactory('CompliantERC20');
-  const contract = await contractFactory.connect(signers.alice).deploy(identityAddress, erc20RulesAddress);
+  const contract = await contractFactory
+    .connect(signers.alice)
+    .deploy(identityAddress, erc20RulesAddress, 'CompliantToken', 'CTOK');
   await contract.waitForDeployment();
 
   return contract;


### PR DESCRIPTION
Simple PR to make the Encrypted ERC20 more flexible and closer to OZ implementation. Just adding name and symbol parameters in constructor of EncryptedERC20 and CompliantERC20.