### PR TITLE
Changed evm version to Shanghai

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -167,7 +167,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 800,
       },
-      evmVersion: 'paris',
+      evmVersion: 'shanghai',
     },
   },
   typechain: {


### PR DESCRIPTION
This still raises the following error : "ProviderError: rpc error: code = Unknown desc = invalid opcode: PUSH0" meaning current node is still incompatible with Shangai fork.
Needing some investigation @youben11 @leventdem @david-zama @immortal-tofu please.