### PR TITLE
fix: updated hardhat config to have same accounts in mocked mode as in fhevm mode

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -141,6 +141,13 @@ const config: HardhatUserConfig = {
     src: './examples',
   },
   networks: {
+    hardhat: {
+      accounts: {
+        count: 10,
+        mnemonic,
+        path: "m/44'/60'/0'/0",
+      },
+    },
     zama: getChainConfig('zama'),
     localDev: getChainConfig('local'),
     local: getChainConfig('local'),


### PR DESCRIPTION
This was needed to easier testing of the oracle contract to get the same deterministic address in both mode.