### PR TITLE
feat: 1day hardlimit for maxTimestamp and isExpired view func

### DIFF
--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -32,6 +32,13 @@ contract TestAsyncDecrypt is OracleCaller {
         xAddress = TFHE.asEaddress(0x8ba1f109551bD432803012645Ac136ddd64DBA72);
     }
 
+    function requestBoolAboveDelay() public {
+        // should revert
+        ebool[] memory cts = new ebool[](1);
+        cts[0] = xBool;
+        Oracle.requestDecryption(cts, this.callbackBool.selector, 0, block.timestamp + 2 days);
+    }
+
     function requestBool() public {
         ebool[] memory cts = new ebool[](1);
         cts[0] = xBool;

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -6,6 +6,8 @@ import "../lib/TFHE.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 
 contract OraclePredeploy is Ownable2Step {
+    uint256 public constant MAX_DELAY = 1 days;
+
     struct DecryptionRequestEBool {
         ebool[] cts;
         address contractCaller;
@@ -64,7 +66,7 @@ contract OraclePredeploy is Ownable2Step {
 
     ebool eTRUE = TFHE.asEbool(true);
 
-    uint256 counter; // tracks the number of decryption requests
+    uint256 public counter; // tracks the number of decryption requests
 
     mapping(address => bool) public isRelayer;
     mapping(uint256 => DecryptionRequestEBool) decryptionRequestsEBool;
@@ -165,6 +167,26 @@ contract OraclePredeploy is Ownable2Step {
         emit RemovedRelayer(relayerAddress);
     }
 
+    function isExpired(uint256 requestID) external view returns (bool) {
+        uint256 timeNow = block.timestamp;
+        return
+            isFulfilled[requestID] ||
+            (timeNow > decryptionRequestsEBool[requestID].maxTimestamp &&
+                decryptionRequestsEBool[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEUint4[requestID].maxTimestamp &&
+                decryptionRequestsEUint4[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEUint8[requestID].maxTimestamp &&
+                decryptionRequestsEUint8[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEUint16[requestID].maxTimestamp &&
+                decryptionRequestsEUint16[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEUint32[requestID].maxTimestamp &&
+                decryptionRequestsEUint32[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEUint64[requestID].maxTimestamp &&
+                decryptionRequestsEUint64[requestID].maxTimestamp != 0) ||
+            (timeNow > decryptionRequestsEAddress[requestID].maxTimestamp &&
+                decryptionRequestsEAddress[requestID].maxTimestamp != 0);
+    }
+
     // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
     // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestBool`.
     function requestDecryptionEBool(
@@ -173,6 +195,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -198,6 +221,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -223,6 +247,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -248,6 +273,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -273,6 +299,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -298,6 +325,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {
@@ -323,6 +351,7 @@ contract OraclePredeploy is Ownable2Step {
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
     ) external returns (uint256 initialCounter) {
+        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
         uint256 len = ct.length;
         for (uint256 i = 0; i < len; i++) {

--- a/test/oracleDecrypt/testAsyncDecrypt.ts
+++ b/test/oracleDecrypt/testAsyncDecrypt.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
+import { ethers, network } from 'hardhat';
 
 import { asyncDecrypt, awaitAllDecryptionResults } from '../asyncDecrypt';
 import { getSigners, initSigners } from '../signers';
@@ -14,6 +14,19 @@ describe('TestAsyncDecrypt', function () {
   beforeEach(async function () {
     const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
     this.contract = await contractFactory.connect(this.signers.alice).deploy();
+  });
+
+  it('test async decrypt bool would fail if maxTimestamp is above 1 day', async function () {
+    if (network.name === 'hardhat') {
+      // mocked mode
+      await expect(this.contract.connect(this.signers.carol).requestBoolAboveDelay()).to.be.revertedWith(
+        'maxTimestamp exceeded MAX_DELAY',
+      );
+    } else {
+      // fhevm-mode
+      const tx = await this.contract.connect(this.signers.carol).requestBoolAboveDelay({ gasLimit: 1_000_000 });
+      await expect(tx.wait()).to.throw;
+    }
   });
 
   it('test async decrypt bool', async function () {


### PR DESCRIPTION
This PR mainly adds a hardcoded maximum delay of 1 day for the `maxTimestamp` parameter when doing a decryption request. This is needed to simplify the logic of the oracle service, if for some reason the relayer goes offline, then it would be enough when restarting the relayer to scan past requests and fulfilment events only up to one day ago.
I also made the `counter` state variable public (to know total number of requests) and added a view function isExpired  which returns true if and only if a `requestID` has already been fulfilled or has exceeded its `maxTimestamp` already. Those 2 last features are not strictly needed for the oracle service but can be useful for debugging.