### PR TITLE
feat: new async-decrypt API

### DIFF
--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -208,6 +208,37 @@ contract TestAsyncDecrypt is OracleCaller {
     function callbackAddress(uint256, address decryptedInput) public onlyOracle returns (address) {
         yAddress = decryptedInput;
         return decryptedInput;
+
+    function requestMixed() public {
+        Ciphertext[] memory cts = new Ciphertext[](10);
+        cts[0] = Oracle.toCiphertext(xBool);
+        cts[1] = Oracle.toCiphertext(xBool);
+        cts[2] = Oracle.toCiphertext(xUint4);
+        cts[3] = Oracle.toCiphertext(xUint8);
+        cts[4] = Oracle.toCiphertext(xUint16);
+        cts[5] = Oracle.toCiphertext(xUint32);
+        cts[6] = Oracle.toCiphertext(xUint64);
+        cts[7] = Oracle.toCiphertext(xUint64);
+        cts[8] = Oracle.toCiphertext(xUint64);
+        cts[9] = Oracle.toCiphertext(xAddress);
+        Oracle.requestDecryption(cts, this.callbackMixed.selector, 0, block.timestamp + 100);
+    }
+
+    function callbackMixed(
+        uint256 /*requestID*/,
+        bool decBool_1,
+        bool decBool_2,
+        uint8 decUint4,
+        uint8 decUint8,
+        uint16 decUint16,
+        uint32 decUint32,
+        uint64 decUint64_1,
+        uint64 decUint64_2,
+        uint64 decUint64_3,
+        address decAddress
+    ) public onlyOracle returns (uint8) {
+        yUint4 = decUint4;
+        return yUint4;
     }
 
     function requestMixed(uint32 input1, uint32 input2) public {

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -250,5 +250,4 @@ contract TestAsyncDecrypt is OracleCaller {
         yAddress = decAddress;
         return yUint4;
     }
-
 }

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -56,6 +56,21 @@ contract TestAsyncDecrypt is OracleCaller {
         return yBool;
     }
 
+    function requestBoolInfinite() public {
+        ebool[] memory cts = new ebool[](1);
+        cts[0] = xBool;
+        Oracle.requestDecryption(cts, this.callbackBoolInfinite.selector, 0, block.timestamp + 100);
+    }
+
+    function callbackBoolInfinite(uint256 /*requestID*/, bool decryptedInput) public onlyOracle returns (bool) {
+        uint256 i = 0;
+        while (1 == 1) {
+            i++;
+        }
+        yBool = decryptedInput;
+        return yBool;
+    }
+
     function requestBoolAboveDelay() public {
         // should revert
         Ciphertext[] memory cts = new Ciphertext[](1);

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -210,7 +210,7 @@ contract TestAsyncDecrypt is OracleCaller {
         return decryptedInput;
     }
 
-    function requestMixed() public {
+    function requestMixed(uint32 input1, uint32 input2) public {
         Ciphertext[] memory cts = new Ciphertext[](10);
         cts[0] = Oracle.toCiphertext(xBool);
         cts[1] = Oracle.toCiphertext(xBool);
@@ -222,11 +222,13 @@ contract TestAsyncDecrypt is OracleCaller {
         cts[7] = Oracle.toCiphertext(xUint64);
         cts[8] = Oracle.toCiphertext(xUint64);
         cts[9] = Oracle.toCiphertext(xAddress);
-        Oracle.requestDecryption(cts, this.callbackMixed.selector, 0, block.timestamp + 100);
+        uint256 requestID = Oracle.requestDecryption(cts, this.callbackMixed.selector, 0, block.timestamp + 100);
+        addParamsUint(requestID, input1);
+        addParamsUint(requestID, input2);
     }
 
     function callbackMixed(
-        uint256,
+        uint256 requestID,
         bool decBool_1,
         bool decBool_2,
         uint8 decUint4,
@@ -238,7 +240,19 @@ contract TestAsyncDecrypt is OracleCaller {
         uint64 decUint64_3,
         address decAddress
     ) public onlyOracle returns (uint8) {
+        yBool = decBool_1;
+        require(decBool_1 == decBool_2, "Wrong decryption");
         yUint4 = decUint4;
+        yUint8 = decUint8;
+        yUint16 = decUint16;
+        uint256[] memory params = getParamsUint(requestID);
+        unchecked {
+            uint32 result = uint32(params[0]) + uint32(params[1]) + decUint32;
+            yUint32 = result;
+        }
+        yUint64 = decUint64_1;
+        require(decUint64_1 == decUint64_2 && decUint64_2 == decUint64_3, "Wrong decryption");
+        yAddress = decAddress;
         return yUint4;
     }
 

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -42,23 +42,8 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function requestBoolInfinite() public {
-        ebool[] memory cts = new ebool[](1);
-        cts[0] = xBool;
-        Oracle.requestDecryption(cts, this.callbackBoolInfinite.selector, 0, block.timestamp + 100);
-    }
-
-    function callbackBoolInfinite(uint256 /*requestID*/, bool decryptedInput) public onlyOracle returns (bool) {
-        uint256 i = 0;
-        while (1 == 1) {
-            i++;
-        }
-        yBool = decryptedInput;
-        return yBool;
-    }
-
-    function requestBoolInfinite() public {
-        ebool[] memory cts = new ebool[](1);
-        cts[0] = xBool;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xBool);
         Oracle.requestDecryption(cts, this.callbackBoolInfinite.selector, 0, block.timestamp + 100);
     }
 
@@ -193,10 +178,20 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function requestSeveralAddresses() public {
-        eaddress[] memory cts = new eaddress[](2);
-        cts[0] = xAddress;
-        cts[1] = xAddress2;
+        Ciphertext[] memory cts = new Ciphertext[](2);
+        cts[0] = Oracle.toCiphertext(xAddress);
+        cts[1] = Oracle.toCiphertext(xAddress2);
         Oracle.requestDecryption(cts, this.callbackAddresses.selector, 0, block.timestamp + 100);
+    }
+
+    function callbackAddresses(
+        uint256 /*requestID*/,
+        address decryptedInput1,
+        address decryptedInput2
+    ) public onlyOracle returns (address) {
+        yAddress = decryptedInput1;
+        yAddress2 = decryptedInput2;
+        return decryptedInput1;
     }
 
     function requestFakeAddress() public {
@@ -256,81 +251,4 @@ contract TestAsyncDecrypt is OracleCaller {
         return yUint4;
     }
 
-    function requestMixed(uint32 input1, uint32 input2) public {
-        Ciphertext[] memory cts = new Ciphertext[](10);
-        cts[0] = Oracle.toCiphertext(xBool);
-        cts[1] = Oracle.toCiphertext(xBool);
-        cts[2] = Oracle.toCiphertext(xUint4);
-        cts[3] = Oracle.toCiphertext(xUint8);
-        cts[4] = Oracle.toCiphertext(xUint16);
-        cts[5] = Oracle.toCiphertext(xUint32);
-        cts[6] = Oracle.toCiphertext(xUint64);
-        cts[7] = Oracle.toCiphertext(xUint64);
-        cts[8] = Oracle.toCiphertext(xUint64);
-        cts[9] = Oracle.toCiphertext(xAddress);
-        uint256 requestID = Oracle.requestDecryption(cts, this.callbackMixed.selector, 0, block.timestamp + 100);
-        addParamsUint(requestID, input1);
-        addParamsUint(requestID, input2);
-    }
-
-    function callbackMixed(
-        uint256 requestID,
-        bool decBool_1,
-        bool decBool_2,
-        uint8 decUint4,
-        uint8 decUint8,
-        uint16 decUint16,
-        uint32 decUint32,
-        uint64 decUint64_1,
-        uint64 decUint64_2,
-        uint64 decUint64_3,
-        address decAddress
-    ) public onlyOracle returns (uint8) {
-        yBool = decBool_1;
-        require(decBool_1 == decBool_2, "Wrong decryption");
-        yUint4 = decUint4;
-        yUint8 = decUint8;
-        yUint16 = decUint16;
-        uint256[] memory params = getParamsUint(requestID);
-        unchecked {
-            uint32 result = uint32(params[0]) + uint32(params[1]) + decUint32;
-            yUint32 = result;
-        }
-        yUint64 = decUint64_1;
-        require(decUint64_1 == decUint64_2 && decUint64_2 == decUint64_3, "Wrong decryption");
-        yAddress = decAddress;
-        return yUint4;
-    }
-
-    function callbackAddresses(
-        uint256 /*requestID*/,
-        address decryptedInput1,
-        address decryptedInput2
-    ) public onlyOracle returns (address) {
-        yAddress = decryptedInput1;
-        yAddress2 = decryptedInput2;
-        return decryptedInput1;
-    }
-
-    function requestSeveralUint64WithDuplicates() public {
-        euint64[] memory cts = new euint64[](4);
-        cts[0] = xUint64;
-        cts[1] = xUint64_2;
-        cts[2] = xUint64_3;
-        cts[3] = xUint64_2;
-        Oracle.requestDecryption(cts, this.callbackSeveralUint64WithDuplicates.selector, 0, block.timestamp + 100);
-    }
-
-    function callbackSeveralUint64WithDuplicates(
-        uint256 /*requestID*/,
-        uint64 decryptedInput,
-        uint64 /*decryptedInput_2*/,
-        uint64 decryptedInput_3,
-        uint64 decryptedInput_4
-    ) public onlyOracle returns (uint64) {
-        yUint64 = decryptedInput;
-        yUint64_2 = decryptedInput_4;
-        yUint64_3 = decryptedInput_3;
-        return decryptedInput;
-    }
 }

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -208,6 +208,7 @@ contract TestAsyncDecrypt is OracleCaller {
     function callbackAddress(uint256, address decryptedInput) public onlyOracle returns (address) {
         yAddress = decryptedInput;
         return decryptedInput;
+    }
 
     function requestMixed() public {
         Ciphertext[] memory cts = new Ciphertext[](10);
@@ -225,7 +226,7 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function callbackMixed(
-        uint256 /*requestID*/,
+        uint256,
         bool decBool_1,
         bool decBool_2,
         uint8 decUint4,

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -70,73 +70,79 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function requestFakeBool() public {
-        ebool[] memory cts = new ebool[](1);
-        cts[0] = ebool.wrap(42);
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EBOOL);
         Oracle.requestDecryption(cts, this.callbackBool.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
     }
 
-    function callbackBool(uint256 /*requestID*/, bool decryptedInput) public onlyOracle returns (bool) {
+    function callbackBool(uint256, bool decryptedInput) public onlyOracle returns (bool) {
         yBool = decryptedInput;
         return yBool;
     }
 
-    function requestFakeUint4() public {
-        euint4[] memory cts = new euint4[](1);
-        cts[0] = euint4.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackUint4.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+    function requestUint4() public {
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xUint4);
+        Oracle.requestDecryption(cts, this.callbackUint4.selector, 0, block.timestamp + 100);
     }
 
-    function callbackUint4(uint256 /*requestID*/, uint8 decryptedInput) public onlyOracle returns (uint8) {
+    function requestFakeUint4() public {
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EUINT4);
+        Oracle.requestDecryption(cts, this.callbackUint4.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
+    }
+
+    function callbackUint4(uint256, uint8 decryptedInput) public onlyOracle returns (uint8) {
         yUint4 = decryptedInput;
         return decryptedInput;
     }
 
     function requestUint8() public {
-        euint8[] memory cts = new euint8[](1);
-        cts[0] = xUint8;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xUint8);
         Oracle.requestDecryption(cts, this.callbackUint8.selector, 0, block.timestamp + 100);
     }
 
     function requestFakeUint8() public {
-        euint8[] memory cts = new euint8[](1);
-        cts[0] = euint8.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackUint8.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EUINT8);
+        Oracle.requestDecryption(cts, this.callbackUint8.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
     }
 
-    function callbackUint8(uint256 /*requestID*/, uint8 decryptedInput) public onlyOracle returns (uint8) {
+    function callbackUint8(uint256, uint8 decryptedInput) public onlyOracle returns (uint8) {
         yUint8 = decryptedInput;
         return decryptedInput;
     }
 
     function requestUint16() public {
-        euint16[] memory cts = new euint16[](1);
-        cts[0] = xUint16;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xUint16);
         Oracle.requestDecryption(cts, this.callbackUint16.selector, 0, block.timestamp + 100);
     }
 
     function requestFakeUint16() public {
-        euint16[] memory cts = new euint16[](1);
-        cts[0] = euint16.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackUint16.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EUINT16);
+        Oracle.requestDecryption(cts, this.callbackUint16.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
     }
 
-    function callbackUint16(uint256 /*requestID*/, uint16 decryptedInput) public onlyOracle returns (uint16) {
+    function callbackUint16(uint256, uint16 decryptedInput) public onlyOracle returns (uint16) {
         yUint16 = decryptedInput;
         return decryptedInput;
     }
 
     function requestUint32(uint32 input1, uint32 input2) public {
-        euint32[] memory cts = new euint32[](1);
-        cts[0] = xUint32;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xUint32);
         uint256 requestID = Oracle.requestDecryption(cts, this.callbackUint32.selector, 0, block.timestamp + 100);
         addParamsUint(requestID, input1);
         addParamsUint(requestID, input2);
     }
 
     function requestFakeUint32() public {
-        euint32[] memory cts = new euint32[](1);
-        cts[0] = euint32.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackUint32.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EUINT32);
+        Oracle.requestDecryption(cts, this.callbackUint32.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
     }
 
     function callbackUint32(uint256 requestID, uint32 decryptedInput) public onlyOracle returns (uint32) {
@@ -149,25 +155,25 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function requestUint64() public {
-        euint64[] memory cts = new euint64[](1);
-        cts[0] = xUint64;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xUint64);
         Oracle.requestDecryption(cts, this.callbackUint64.selector, 0, block.timestamp + 100);
     }
 
     function requestFakeUint64() public {
-        euint64[] memory cts = new euint64[](1);
-        cts[0] = euint64.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackUint64.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EUINT64);
+        Oracle.requestDecryption(cts, this.callbackUint64.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
     }
 
-    function callbackUint64(uint256 /*requestID*/, uint64 decryptedInput) public onlyOracle returns (uint64) {
+    function callbackUint64(uint256, uint64 decryptedInput) public onlyOracle returns (uint64) {
         yUint64 = decryptedInput;
         return decryptedInput;
     }
 
     function requestAddress() public {
-        eaddress[] memory cts = new eaddress[](1);
-        cts[0] = xAddress;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xAddress);
         Oracle.requestDecryption(cts, this.callbackAddress.selector, 0, block.timestamp + 100);
     }
 
@@ -179,14 +185,15 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function requestFakeAddress() public {
-        eaddress[] memory cts = new eaddress[](1);
-        cts[0] = eaddress.wrap(42);
-        Oracle.requestDecryption(cts, this.callbackAddress.selector, 0, block.timestamp + 100); // this should revert because previous ebool is not honestly obtained
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Ciphertext(42, CiphertextType.EADDRESS);
+        Oracle.requestDecryption(cts, this.callbackAddress.selector, 0, block.timestamp + 100); // this should revert because previous handle is not honestly obtained
     }
 
-    function callbackAddress(uint256 /*requestID*/, address decryptedInput) public onlyOracle returns (address) {
+    function callbackAddress(uint256, address decryptedInput) public onlyOracle returns (address) {
         yAddress = decryptedInput;
         return decryptedInput;
+    }
 
     function requestMixed() public {
         Ciphertext[] memory cts = new Ciphertext[](10);
@@ -204,7 +211,7 @@ contract TestAsyncDecrypt is OracleCaller {
     }
 
     function callbackMixed(
-        uint256 /*requestID*/,
+        uint256,
         bool decBool_1,
         bool decBool_2,
         uint8 decUint4,

--- a/examples/TestAsyncDecrypt.sol
+++ b/examples/TestAsyncDecrypt.sol
@@ -58,14 +58,14 @@ contract TestAsyncDecrypt is OracleCaller {
 
     function requestBoolAboveDelay() public {
         // should revert
-        ebool[] memory cts = new ebool[](1);
-        cts[0] = xBool;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xBool);
         Oracle.requestDecryption(cts, this.callbackBool.selector, 0, block.timestamp + 2 days);
     }
 
     function requestBool() public {
-        ebool[] memory cts = new ebool[](1);
-        cts[0] = xBool;
+        Ciphertext[] memory cts = new Ciphertext[](1);
+        cts[0] = Oracle.toCiphertext(xBool);
         Oracle.requestDecryption(cts, this.callbackBool.selector, 0, block.timestamp + 100);
     }
 
@@ -78,12 +78,6 @@ contract TestAsyncDecrypt is OracleCaller {
     function callbackBool(uint256 /*requestID*/, bool decryptedInput) public onlyOracle returns (bool) {
         yBool = decryptedInput;
         return yBool;
-    }
-
-    function requestUint4() public {
-        euint4[] memory cts = new euint4[](1);
-        cts[0] = xUint4;
-        Oracle.requestDecryption(cts, this.callbackUint4.selector, 0, block.timestamp + 100);
     }
 
     function requestFakeUint4() public {
@@ -193,6 +187,37 @@ contract TestAsyncDecrypt is OracleCaller {
     function callbackAddress(uint256 /*requestID*/, address decryptedInput) public onlyOracle returns (address) {
         yAddress = decryptedInput;
         return decryptedInput;
+
+    function requestMixed() public {
+        Ciphertext[] memory cts = new Ciphertext[](10);
+        cts[0] = Oracle.toCiphertext(xBool);
+        cts[1] = Oracle.toCiphertext(xBool);
+        cts[2] = Oracle.toCiphertext(xUint4);
+        cts[3] = Oracle.toCiphertext(xUint8);
+        cts[4] = Oracle.toCiphertext(xUint16);
+        cts[5] = Oracle.toCiphertext(xUint32);
+        cts[6] = Oracle.toCiphertext(xUint64);
+        cts[7] = Oracle.toCiphertext(xUint64);
+        cts[8] = Oracle.toCiphertext(xUint64);
+        cts[9] = Oracle.toCiphertext(xAddress);
+        Oracle.requestDecryption(cts, this.callbackMixed.selector, 0, block.timestamp + 100);
+    }
+
+    function callbackMixed(
+        uint256 /*requestID*/,
+        bool decBool_1,
+        bool decBool_2,
+        uint8 decUint4,
+        uint8 decUint8,
+        uint16 decUint16,
+        uint32 decUint32,
+        uint64 decUint64_1,
+        uint64 decUint64_2,
+        uint64 decUint64_3,
+        address decAddress
+    ) public onlyOracle returns (uint8) {
+        yUint4 = decUint4;
+        return yUint4;
     }
 
     function callbackAddresses(

--- a/launch-fhevm.sh
+++ b/launch-fhevm.sh
@@ -11,7 +11,7 @@ ORACLE_CONTRACT_PREDEPLOY_ADDRESS=$(grep ORACLE_CONTRACT_PREDEPLOY_ADDRESS oracl
 docker run -d -i -p 8545:8545 --rm --name fhevm \
   -e PRIVATE_KEY_ORACLE_RELAYER="$PRIVATE_KEY_ORACLE_RELAYER" \
   -e ORACLE_CONTRACT_PREDEPLOY_ADDRESS="$ORACLE_CONTRACT_PREDEPLOY_ADDRESS" \
-  ghcr.io/zama-ai/ethermint-dev-node:v0.4.2
+  ghcr.io/zama-ai/ethermint-dev-node:v0.4.1
   
 sleep 10
 

--- a/launch-fhevm.sh
+++ b/launch-fhevm.sh
@@ -11,7 +11,7 @@ ORACLE_CONTRACT_PREDEPLOY_ADDRESS=$(grep ORACLE_CONTRACT_PREDEPLOY_ADDRESS oracl
 docker run -d -i -p 8545:8545 --rm --name fhevm \
   -e PRIVATE_KEY_ORACLE_RELAYER="$PRIVATE_KEY_ORACLE_RELAYER" \
   -e ORACLE_CONTRACT_PREDEPLOY_ADDRESS="$ORACLE_CONTRACT_PREDEPLOY_ADDRESS" \
-  ghcr.io/zama-ai/ethermint-dev-node:v0.4.1
+  ghcr.io/zama-ai/ethermint-dev-node:v0.4.3-new-api
   
 sleep 10
 

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -94,23 +94,14 @@ contract OraclePredeploy is Ownable2Step {
             uint256 handle = cts[i].ctHandle;
             require(handle != 0, "Ciphertext is not initialized");
             uint8 ctType = uint8(cts[i].ctType);
-            if (ctType == 0) {
-                TFHE.and(ebool.wrap(handle), ebool.wrap(handle)); // this is similar to no-op, except it would fail if `handle` is a "fake" handle, needed to check that ciphertext is honestly obtained
-            } else if (ctType == 1) {
-                TFHE.and(euint4.wrap(handle), euint4.wrap(handle));
-            } else if (ctType == 2) {
-                TFHE.and(euint8.wrap(handle), euint8.wrap(handle));
-            } else if (ctType == 3) {
-                TFHE.and(euint16.wrap(handle), euint16.wrap(handle));
-            } else if (ctType == 4) {
-                TFHE.and(euint32.wrap(handle), euint32.wrap(handle));
-            } else if (ctType == 5) {
-                TFHE.and(euint64.wrap(handle), euint64.wrap(handle));
-            } else if (ctType == 6) {
-                revert NotImplementedError();
+            if (ctType <= 5) {
+                Impl.and(handle, handle); // this is similar to no-op, except it would fail if `handle` is a "fake" handle, needed to check that ciphertext is honestly obtained
+            } else if (ctType == 7) {
+                Impl.eq(handle, handle, 0x00); // similar to previous no-op, used here because `` not supported by eaddress type
+            } 
             } else {
-                TFHE.eq(eaddress.wrap(handle), eaddress.wrap(handle));
-            }
+                revert NotImplementedError();
+            } 
             decryptionReq.cts.push(cts[i]);
         }
         decryptionReq.contractCaller = msg.sender;

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -32,6 +32,8 @@ contract OraclePredeploy is Ownable2Step {
         uint256 maxTimestamp;
     }
 
+    ebool eTRUE = TFHE.asEbool(true);
+
     uint256 public counter; // tracks the number of decryption requests
 
     mapping(address => bool) public isRelayer;
@@ -83,30 +85,44 @@ contract OraclePredeploy is Ownable2Step {
     }
 
     function approveEBool(ebool x) external {
+        TFHE.and(x, eTRUE); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEBools[counter].push(x);
     }
 
     function approveEUint4(euint4 x) external {
+        TFHE.shl(x, 0); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEUint4s[counter].push(x);
     }
 
     function approveEUint8(euint8 x) external {
+        TFHE.shl(x, 0); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEUint8s[counter].push(x);
     }
 
     function approveEUint16(euint16 x) external {
+        TFHE.shl(x, 0); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEUint16s[counter].push(x);
     }
 
     function approveEUint32(euint32 x) external {
+        TFHE.shl(x, 0); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEUint32s[counter].push(x);
     }
 
     function approveEUint64(euint64 x) external {
+        TFHE.shl(x, 0); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEUint64s[counter].push(x);
     }
 
     function approveEAddress(eaddress x) external {
+        TFHE.eq(x, x); // this is similar to no-op, except it would fail if x is a "fake" handle,
+        // not corresponding to a verified ciphertext in privileged memory
         verifiedEAddresses[counter].push(x);
     }
 

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -97,11 +97,10 @@ contract OraclePredeploy is Ownable2Step {
             if (ctType <= 5) {
                 Impl.and(handle, handle); // this is similar to no-op, except it would fail if `handle` is a "fake" handle, needed to check that ciphertext is honestly obtained
             } else if (ctType == 7) {
-                Impl.eq(handle, handle, 0x00); // similar to previous no-op, used here because `` not supported by eaddress type
-            } 
+                Impl.eq(handle, handle, false); // similar to previous no-op, used here because `Impl.and` not supported by eaddress type
             } else {
                 revert NotImplementedError();
-            } 
+            }
             decryptionReq.cts.push(cts[i]);
         }
         decryptionReq.contractCaller = msg.sender;

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -5,138 +5,52 @@ pragma solidity ^0.8.20;
 import "../lib/TFHE.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 
+enum CiphertextType {
+    EBOOL,
+    EUINT4,
+    EUINT8,
+    EUINT16,
+    EUINT32,
+    EUINT64,
+    EUINT128,
+    EADDRESS
+}
+
+struct Ciphertext {
+    uint256 ctHandle;
+    CiphertextType ctType;
+}
+
 contract OraclePredeploy is Ownable2Step {
     uint256 public constant MAX_DELAY = 1 days;
 
-    struct DecryptionRequestEBool {
-        ebool[] cts;
+    struct DecryptionRequest {
+        Ciphertext[] cts;
         address contractCaller;
         bytes4 callbackSelector;
         uint256 msgValue;
         uint256 maxTimestamp;
     }
-
-    struct DecryptionRequestEUint4 {
-        euint4[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    struct DecryptionRequestEUint8 {
-        euint8[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    struct DecryptionRequestEUint16 {
-        euint16[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    struct DecryptionRequestEUint32 {
-        euint32[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    struct DecryptionRequestEUint64 {
-        euint64[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    struct DecryptionRequestEAddress {
-        eaddress[] cts;
-        address contractCaller;
-        bytes4 callbackSelector;
-        uint256 msgValue;
-        uint256 maxTimestamp;
-    }
-
-    ebool eTRUE = TFHE.asEbool(true);
 
     uint256 public counter; // tracks the number of decryption requests
 
     mapping(address => bool) public isRelayer;
-    mapping(uint256 => DecryptionRequestEBool) decryptionRequestsEBool;
-    mapping(uint256 => DecryptionRequestEUint4) decryptionRequestsEUint4;
-    mapping(uint256 => DecryptionRequestEUint8) decryptionRequestsEUint8;
-    mapping(uint256 => DecryptionRequestEUint16) decryptionRequestsEUint16;
-    mapping(uint256 => DecryptionRequestEUint32) decryptionRequestsEUint32;
-    mapping(uint256 => DecryptionRequestEUint64) decryptionRequestsEUint64;
-    mapping(uint256 => DecryptionRequestEAddress) decryptionRequestsEAddress;
-    mapping(uint256 => bool) isFulfilled;
+    mapping(uint256 => DecryptionRequest) internal decryptionRequests;
+    mapping(uint256 => bool) internal isFulfilled;
+
+    mapping(uint256 => ebool[]) internal verifiedEBools; // to check that ciphertexts have been honestly obtained via privileged storage
+    mapping(uint256 => euint4[]) internal verifiedEUint4s;
+    mapping(uint256 => euint8[]) internal verifiedEUint8s;
+    mapping(uint256 => euint16[]) internal verifiedEUint16s;
+    mapping(uint256 => euint32[]) internal verifiedEUint32s;
+    mapping(uint256 => euint64[]) internal verifiedEUint64s;
+    mapping(uint256 => eaddress[]) internal verifiedEAddresses;
 
     constructor(address predeployOwner) Ownable(predeployOwner) {}
 
-    event EventDecryptionEBool(
+    event EventDecryption(
         uint256 indexed requestID,
-        ebool[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEUint4(
-        uint256 indexed requestID,
-        euint4[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEUint8(
-        uint256 indexed requestID,
-        euint8[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEUint16(
-        uint256 indexed requestID,
-        euint16[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEUint32(
-        uint256 indexed requestID,
-        euint32[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEUint64(
-        uint256 indexed requestID,
-        euint64[] cts,
-        address contractCaller,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    );
-
-    event EventDecryptionEAddress(
-        uint256 indexed requestID,
-        eaddress[] cts,
+        Ciphertext[] cts,
         address contractCaller,
         bytes4 callbackSelector,
         uint256 msgValue,
@@ -147,13 +61,7 @@ contract OraclePredeploy is Ownable2Step {
 
     event RemovedRelayer(address indexed realyer);
 
-    event ResultCallbackBool(uint256 indexed requestID, bool success, bytes result);
-    event ResultCallbackUint4(uint256 indexed requestID, bool success, bytes result);
-    event ResultCallbackUint8(uint256 indexed requestID, bool success, bytes result);
-    event ResultCallbackUint16(uint256 indexed requestID, bool success, bytes result);
-    event ResultCallbackUint32(uint256 indexed requestID, bool success, bytes result);
-    event ResultCallbackUint64(uint256 indexed requestID, bool success, bytes result);
-    event ResultcallbackAddress(uint256 indexed requestID, bool success, bytes result);
+    event ResultCallback(uint256 indexed requestID, bool success, bytes result);
 
     function addRelayer(address relayerAddress) external onlyOwner {
         require(!isRelayer[relayerAddress], "Address is already relayer");
@@ -171,26 +79,42 @@ contract OraclePredeploy is Ownable2Step {
         uint256 timeNow = block.timestamp;
         return
             isFulfilled[requestID] ||
-            (timeNow > decryptionRequestsEBool[requestID].maxTimestamp &&
-                decryptionRequestsEBool[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEUint4[requestID].maxTimestamp &&
-                decryptionRequestsEUint4[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEUint8[requestID].maxTimestamp &&
-                decryptionRequestsEUint8[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEUint16[requestID].maxTimestamp &&
-                decryptionRequestsEUint16[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEUint32[requestID].maxTimestamp &&
-                decryptionRequestsEUint32[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEUint64[requestID].maxTimestamp &&
-                decryptionRequestsEUint64[requestID].maxTimestamp != 0) ||
-            (timeNow > decryptionRequestsEAddress[requestID].maxTimestamp &&
-                decryptionRequestsEAddress[requestID].maxTimestamp != 0);
+            (timeNow > decryptionRequests[requestID].maxTimestamp && decryptionRequests[requestID].maxTimestamp != 0);
     }
 
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestBool`.
-    function requestDecryptionEBool(
-        ebool[] memory ct,
+    function approveEBool(ebool x) external {
+        verifiedEBools[counter].push(x);
+    }
+
+    function approveEUint4(euint4 x) external {
+        verifiedEUint4s[counter].push(x);
+    }
+
+    function approveEUint8(euint8 x) external {
+        verifiedEUint8s[counter].push(x);
+    }
+
+    function approveEUint16(euint16 x) external {
+        verifiedEUint16s[counter].push(x);
+    }
+
+    function approveEUint32(euint32 x) external {
+        verifiedEUint32s[counter].push(x);
+    }
+
+    function approveEUint64(euint64 x) external {
+        verifiedEUint64s[counter].push(x);
+    }
+
+    function approveEAddress(eaddress x) external {
+        verifiedEAddresses[counter].push(x);
+    }
+
+    // Requests the decryption of n ciphertexts `ctsHandles` with the result returned in a callback.
+    // `ctsHandles` is an array of handles. `ctsTypes` is an array of CiphertextTypes. `ctsHandles[i]`'s type MUST be `ctsTypes[i]`.
+    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ctsHandles[0]),decrypt(ctsHandles[1]),...,decrypt(ctsHandles[n-1])] as calldata via `fulfillRequest`.
+    function requestDecryption(
+        Ciphertext[] calldata cts,
         bytes4 callbackSelector,
         uint256 msgValue, // msg.value of callback tx, if callback is payable
         uint256 maxTimestamp
@@ -198,335 +122,36 @@ contract OraclePredeploy is Ownable2Step {
         require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
         require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
         initialCounter = counter;
-        uint256 len = ct.length;
+        uint256 len = cts.length;
+        DecryptionRequest storage decryptionReq = decryptionRequests[initialCounter];
         for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.and(ct[i], eTRUE); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
+            require(cts[i].ctHandle != 0, "Ciphertext is not initialized");
+            decryptionReq.cts.push(cts[i]);
         }
-        DecryptionRequestEBool memory decryptionReq = DecryptionRequestEBool(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEBool[initialCounter] = decryptionReq;
-        emit EventDecryptionEBool(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
+        decryptionReq.contractCaller = msg.sender;
+        decryptionReq.callbackSelector = callbackSelector;
+        decryptionReq.msgValue = msgValue;
+        decryptionReq.maxTimestamp = maxTimestamp;
+        emit EventDecryption(initialCounter, cts, msg.sender, callbackSelector, msgValue, maxTimestamp);
         counter++;
     }
 
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestUint8`.
-    function requestDecryptionEUint4(
-        euint4[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.shl(ct[i], 0); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEUint4 memory decryptionReq = DecryptionRequestEUint4(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEUint4[initialCounter] = decryptionReq;
-        emit EventDecryptionEUint4(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestUint8`.
-    function requestDecryptionEUint8(
-        euint8[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.shl(ct[i], 0); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEUint8 memory decryptionReq = DecryptionRequestEUint8(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEUint8[initialCounter] = decryptionReq;
-        emit EventDecryptionEUint8(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestUint16`.
-    function requestDecryptionEUint16(
-        euint16[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.shl(ct[i], 0); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEUint16 memory decryptionReq = DecryptionRequestEUint16(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEUint16[initialCounter] = decryptionReq;
-        emit EventDecryptionEUint16(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via  via `fulfillRequestUint32`.
-    function requestDecryptionEUint32(
-        euint32[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.shl(ct[i], 0); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEUint32 memory decryptionReq = DecryptionRequestEUint32(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEUint32[initialCounter] = decryptionReq;
-        emit EventDecryptionEUint32(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `fulfillRequestUint64`.
-    function requestDecryptionEUint64(
-        euint64[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.shl(ct[i], 0); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEUint64 memory decryptionReq = DecryptionRequestEUint64(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEUint64[initialCounter] = decryptionReq;
-        emit EventDecryptionEUint64(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    // Requests the decryption of n ciphertexts `ct`s with the result returned in a callback.
-    // During callback, msg.sender is called with [callbackSelector,requestID,decrypt(ct[0]),decrypt(ct[1]),...,decrypt(ct[n-1])] as calldata via `FulfillRequestAddress`.
-    function requestDecryptionAddress(
-        eaddress[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue, // msg.value of callback tx, if callback is payable
-        uint256 maxTimestamp
-    ) external returns (uint256 initialCounter) {
-        require(maxTimestamp > block.timestamp, "maxTimestamp must be a future date");
-        require(maxTimestamp <= block.timestamp + MAX_DELAY, "maxTimestamp exceeded MAX_DELAY");
-        initialCounter = counter;
-        uint256 len = ct.length;
-        for (uint256 i = 0; i < len; i++) {
-            require(TFHE.isInitialized(ct[i]), "Ciphertext is not initialized");
-            TFHE.eq(ct[i], ct[i]); // this is similar to no-op, except it would fail if ct is a "fake" handle,
-            // not corresponding to a verified ciphertext in privileged memory
-        }
-        DecryptionRequestEAddress memory decryptionReq = DecryptionRequestEAddress(
-            ct,
-            msg.sender,
-            callbackSelector,
-            msgValue,
-            maxTimestamp
-        );
-        decryptionRequestsEAddress[initialCounter] = decryptionReq;
-        emit EventDecryptionEAddress(initialCounter, ct, msg.sender, callbackSelector, msgValue, maxTimestamp);
-        counter++;
-    }
-
-    function fulfillRequestBool(
+    // Called by the relayer to pass the decryption results from the KMS to the callback function
+    // `decryptedCts` is a bytes array containing the abi-encoded concatenation of decryption results.
+    function fulfillRequest(
         uint256 requestID,
-        bool[] memory decryptedCt /*, bytes memory signatureKMS */
+        bytes memory decryptedCts /*, bytes memory signatureKMS */
     ) external payable onlyRelayer {
         // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
         require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEBool memory decryptionReq = decryptionRequestsEBool[requestID];
+        DecryptionRequest memory decryptionReq = decryptionRequests[requestID];
         require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
         bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
+        callbackCalldata = abi.encodePacked(callbackCalldata, decryptedCts); // decryptedCts MUST be correctly abi-encoded by the relayer, according to the requested `ctsTypes`
         (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
             callbackCalldata
         );
-        emit ResultCallbackBool(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestUint4(
-        uint256 requestID,
-        uint8[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEUint4 memory decryptionReq = decryptionRequestsEUint4[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultCallbackUint4(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestUint8(
-        uint256 requestID,
-        uint8[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEUint8 memory decryptionReq = decryptionRequestsEUint8[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultCallbackUint8(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestUint16(
-        uint256 requestID,
-        uint16[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEUint16 memory decryptionReq = decryptionRequestsEUint16[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultCallbackUint16(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestUint32(
-        uint256 requestID,
-        uint32[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEUint32 memory decryptionReq = decryptionRequestsEUint32[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultCallbackUint32(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestUint64(
-        uint256 requestID,
-        uint64[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEUint64 memory decryptionReq = decryptionRequestsEUint64[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(decryptedCt[i]));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultCallbackUint64(requestID, success, result);
-        isFulfilled[requestID] = true;
-    }
-
-    function fulfillRequestAddress(
-        uint256 requestID,
-        uint160[] memory decryptedCt /*, bytes memory signatureKMS */
-    ) external payable onlyRelayer {
-        // TODO: check EIP712-signature of the DecryptionRequest struct by the KMS (waiting for signature scheme specification of KMS to be decided first)
-        require(!isFulfilled[requestID], "Request is already fulfilled");
-        DecryptionRequestEAddress memory decryptionReq = decryptionRequestsEAddress[requestID];
-        require(block.timestamp <= decryptionReq.maxTimestamp, "Too late");
-        uint256 len = decryptedCt.length;
-        bytes memory callbackCalldata = abi.encodeWithSelector(decryptionReq.callbackSelector, requestID);
-        for (uint256 i; i < len; i++) {
-            callbackCalldata = abi.encodePacked(callbackCalldata, abi.encode(address(decryptedCt[i])));
-        }
-        (bool success, bytes memory result) = (decryptionReq.contractCaller).call{value: decryptionReq.msgValue}(
-            callbackCalldata
-        );
-        emit ResultcallbackAddress(requestID, success, result);
+        emit ResultCallback(requestID, success, result);
         isFulfilled[requestID] = true;
     }
 

--- a/oracle/OraclePredeploy.sol
+++ b/oracle/OraclePredeploy.sol
@@ -69,7 +69,7 @@ contract OraclePredeploy is Ownable2Step {
         emit RemovedRelayer(relayerAddress);
     }
 
-    function isExpired(uint256 requestID) external view returns (bool) {
+    function isExpiredOrFulfilled(uint256 requestID) external view returns (bool) {
         uint256 timeNow = block.timestamp;
         return
             isFulfilled[requestID] ||

--- a/oracle/lib/Oracle.sol
+++ b/oracle/lib/Oracle.sol
@@ -12,38 +12,31 @@ library Oracle {
         return ORACLE_CONTRACT_PREDEPLOY_ADDRESS;
     }
 
-    function toCiphertext(ebool newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEBool(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(ebool newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: ebool.unwrap(newCT), ctType: CiphertextType.EBOOL});
     }
 
-    function toCiphertext(euint4 newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEUint4(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(euint4 newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: euint4.unwrap(newCT), ctType: CiphertextType.EUINT4});
     }
 
-    function toCiphertext(euint8 newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEUint8(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(euint8 newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: euint8.unwrap(newCT), ctType: CiphertextType.EUINT8});
     }
 
-    function toCiphertext(euint16 newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEUint16(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(euint16 newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: euint16.unwrap(newCT), ctType: CiphertextType.EUINT16});
     }
 
-    function toCiphertext(euint32 newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEUint32(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(euint32 newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: euint32.unwrap(newCT), ctType: CiphertextType.EUINT32});
     }
 
-    function toCiphertext(euint64 newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEUint64(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(euint64 newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: euint64.unwrap(newCT), ctType: CiphertextType.EUINT64});
     }
 
-    function toCiphertext(eaddress newCT) internal returns (Ciphertext memory ct) {
-        oraclePredeploy.approveEAddress(newCT); // to make sure that ciphertext is honestly obtained
+    function toCiphertext(eaddress newCT) internal pure returns (Ciphertext memory ct) {
         ct = Ciphertext({ctHandle: eaddress.unwrap(newCT), ctType: CiphertextType.EADDRESS});
     }
 

--- a/oracle/lib/Oracle.sol
+++ b/oracle/lib/Oracle.sol
@@ -12,66 +12,47 @@ library Oracle {
         return ORACLE_CONTRACT_PREDEPLOY_ADDRESS;
     }
 
-    function requestDecryption(
-        ebool[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEBool(ct, callbackSelector, msgValue, maxTimestamp);
+    function toCiphertext(ebool newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEBool(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: ebool.unwrap(newCT), ctType: CiphertextType.EBOOL});
+    }
+
+    function toCiphertext(euint4 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint4(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: euint4.unwrap(newCT), ctType: CiphertextType.EUINT4});
+    }
+
+    function toCiphertext(euint8 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint8(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: euint8.unwrap(newCT), ctType: CiphertextType.EUINT8});
+    }
+
+    function toCiphertext(euint16 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint16(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: euint16.unwrap(newCT), ctType: CiphertextType.EUINT16});
+    }
+
+    function toCiphertext(euint32 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint32(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: euint32.unwrap(newCT), ctType: CiphertextType.EUINT32});
+    }
+
+    function toCiphertext(euint64 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint64(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: euint64.unwrap(newCT), ctType: CiphertextType.EUINT64});
+    }
+
+    function toCiphertext(eaddress newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEAddress(newCT); // to make sure that ciphertext is honestly obtained
+        ct = Ciphertext({ctHandle: eaddress.unwrap(newCT), ctType: CiphertextType.EADDRESS});
     }
 
     function requestDecryption(
-        euint4[] memory ct,
+        Ciphertext[] memory cts,
         bytes4 callbackSelector,
         uint256 msgValue,
         uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEUint4(ct, callbackSelector, msgValue, maxTimestamp);
-    }
-
-    function requestDecryption(
-        euint8[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEUint8(ct, callbackSelector, msgValue, maxTimestamp);
-    }
-
-    function requestDecryption(
-        euint16[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEUint16(ct, callbackSelector, msgValue, maxTimestamp);
-    }
-
-    function requestDecryption(
-        euint32[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEUint32(ct, callbackSelector, msgValue, maxTimestamp);
-    }
-
-    function requestDecryption(
-        euint64[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionEUint64(ct, callbackSelector, msgValue, maxTimestamp);
-    }
-
-    function requestDecryption(
-        eaddress[] memory ct,
-        bytes4 callbackSelector,
-        uint256 msgValue,
-        uint256 maxTimestamp
-    ) internal returns (uint256 initialCounter) {
-        initialCounter = oraclePredeploy.requestDecryptionAddress(ct, callbackSelector, msgValue, maxTimestamp);
+    ) internal returns (uint256 requestID) {
+        requestID = oraclePredeploy.requestDecryption(cts, callbackSelector, msgValue, maxTimestamp);
     }
 }

--- a/oracle/lib/Oracle.sol
+++ b/oracle/lib/Oracle.sol
@@ -12,31 +12,38 @@ library Oracle {
         return ORACLE_CONTRACT_PREDEPLOY_ADDRESS;
     }
 
-    function toCiphertext(ebool newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(ebool newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEBool(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: ebool.unwrap(newCT), ctType: CiphertextType.EBOOL});
     }
 
-    function toCiphertext(euint4 newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(euint4 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint4(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: euint4.unwrap(newCT), ctType: CiphertextType.EUINT4});
     }
 
-    function toCiphertext(euint8 newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(euint8 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint8(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: euint8.unwrap(newCT), ctType: CiphertextType.EUINT8});
     }
 
-    function toCiphertext(euint16 newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(euint16 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint16(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: euint16.unwrap(newCT), ctType: CiphertextType.EUINT16});
     }
 
-    function toCiphertext(euint32 newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(euint32 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint32(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: euint32.unwrap(newCT), ctType: CiphertextType.EUINT32});
     }
 
-    function toCiphertext(euint64 newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(euint64 newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEUint64(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: euint64.unwrap(newCT), ctType: CiphertextType.EUINT64});
     }
 
-    function toCiphertext(eaddress newCT) internal pure returns (Ciphertext memory ct) {
+    function toCiphertext(eaddress newCT) internal returns (Ciphertext memory ct) {
+        oraclePredeploy.approveEAddress(newCT); // to make sure that ciphertext is honestly obtained
         ct = Ciphertext({ctHandle: eaddress.unwrap(newCT), ctType: CiphertextType.EADDRESS});
     }
 

--- a/test/asyncDecrypt.ts
+++ b/test/asyncDecrypt.ts
@@ -2,10 +2,21 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import { ethers } from 'hardhat';
 
-import { OraclePredeploy } from '../../types';
+import { OraclePredeploy } from '../types';
 import { waitNBlocks } from './utils';
 
 const network = process.env.HARDHAT_NETWORK;
+
+const CiphertextType = {
+  0: 'bool',
+  1: 'uint8', // corresponding to euint4
+  2: 'uint8', // corresponding to euint8
+  3: 'uint16',
+  4: 'uint32',
+  5: 'uint64',
+  6: 'uint128',
+  7: 'address',
+};
 
 const currentTime = (): string => {
   const now = new Date();
@@ -17,23 +28,11 @@ const privKeyRelayer = process.env.PRIVATE_KEY_ORACLE_RELAYER;
 const relayer = new ethers.Wallet(privKeyRelayer!, ethers.provider);
 
 const argEvents =
-  '(uint256 indexed requestID, uint256[] cts, address contractCaller, bytes4 callbackSelector, uint256 msgValue, uint256 maxTimestamp)';
-const ifaceEventDecryptionEBool = new ethers.Interface(['event EventDecryptionEBool' + argEvents]);
-const ifaceEventDecryptionEUint4 = new ethers.Interface(['event EventDecryptionEUint4' + argEvents]);
-const ifaceEventDecryptionEUint8 = new ethers.Interface(['event EventDecryptionEUint8' + argEvents]);
-const ifaceEventDecryptionEUint16 = new ethers.Interface(['event EventDecryptionEUint16' + argEvents]);
-const ifaceEventDecryptionEUint32 = new ethers.Interface(['event EventDecryptionEUint32' + argEvents]);
-const ifaceEventDecryptionEUint64 = new ethers.Interface(['event EventDecryptionEUint64' + argEvents]);
-const ifaceEventDecryptionEAddress = new ethers.Interface(['event EventDecryptionEAddress' + argEvents]);
+  '(uint256 indexed requestID, tuple(uint256 ctHandle, uint8 ctType)[] cts, address contractCaller, bytes4 callbackSelector, uint256 msgValue, uint256 maxTimestamp)';
+const ifaceEventDecryption = new ethers.Interface(['event EventDecryption' + argEvents]);
 
 const argEvents2 = '(uint256 indexed requestID, bool success, bytes result)';
-const ifaceResultCallbackBool = new ethers.Interface(['event ResultCallbackBool' + argEvents2]);
-const ifaceResultCallbackUint4 = new ethers.Interface(['event ResultCallbackUint4' + argEvents2]);
-const ifaceResultCallbackUint8 = new ethers.Interface(['event ResultCallbackUint8' + argEvents2]);
-const ifaceResultCallbackUint16 = new ethers.Interface(['event ResultCallbackUint16' + argEvents2]);
-const ifaceResultCallbackUint32 = new ethers.Interface(['event ResultCallbackUint32' + argEvents2]);
-const ifaceResultCallbackUint64 = new ethers.Interface(['event ResultCallbackUint64' + argEvents2]);
-const ifaceResultcallbackAddress = new ethers.Interface(['event ResultcallbackAddress' + argEvents2]);
+const ifaceResultCallback = new ethers.Interface(['event ResultCallback' + argEvents2]);
 
 let oracle: OraclePredeploy;
 let firstBlockListening: number;
@@ -43,90 +42,15 @@ export const asyncDecrypt = async (): Promise<void> => {
   // this function will emit logs for every request and fulfilment of a decryption
   oracle = await ethers.getContractAt('OraclePredeploy', parsedEnv.ORACLE_CONTRACT_PREDEPLOY_ADDRESS);
   oracle.on(
-    'EventDecryptionEBool',
+    'EventDecryption',
     async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
       const blockNumber = eventData.log.blockNumber;
-      console.log(`${await currentTime()} - Requested ebool decrypt on block ${blockNumber} (requestID ${requestID})`);
+      console.log(`${await currentTime()} - Requested decrypt on block ${blockNumber} (requestID ${requestID})`);
     },
   );
-  oracle.on('ResultCallbackBool', async (requestID, success, result, eventData) => {
+  oracle.on('ResultCallback', async (requestID, success, result, eventData) => {
     const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled ebool decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-  oracle.on(
-    'EventDecryptionEUint4',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(`${await currentTime()} - Requested euint4 decrypt on block ${blockNumber} (requestID ${requestID})`);
-    },
-  );
-  oracle.on('ResultCallbackUint4', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled euint4 decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-  oracle.on(
-    'EventDecryptionEUint8',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(`${await currentTime()} - Requested euint8 decrypt on block ${blockNumber} (requestID ${requestID})`);
-    },
-  );
-  oracle.on('ResultCallbackUint8', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled euint8 decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-  oracle.on(
-    'EventDecryptionEUint16',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(
-        `${await currentTime()} - Requested euint16 decrypt on block ${blockNumber} (requestID ${requestID})`,
-      );
-    },
-  );
-  oracle.on('ResultCallbackUint16', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled euint16 decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-  oracle.on(
-    'EventDecryptionEUint32',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(
-        `${await currentTime()} - Requested euint32 decrypt on block ${blockNumber} (requestID ${requestID})`,
-      );
-    },
-  );
-  oracle.on('ResultCallbackUint32', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled euint32 decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-  oracle.on(
-    'EventDecryptionEUint64',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(
-        `${await currentTime()} - Requested euint64 decrypt on block ${blockNumber} (requestID ${requestID})`,
-      );
-    },
-  );
-  oracle.on('ResultCallbackUint64', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled euint64 decrypt on block ${blockNumber} (requestID ${requestID})`);
-  });
-
-  oracle.on(
-    'EventDecryptionEAddress',
-    async (requestID, cts, contractCaller, callbackSelector, msgValue, maxTimestamp, eventData) => {
-      const blockNumber = eventData.log.blockNumber;
-      console.log(
-        `${await currentTime()} - Requested eaddress decrypt on block ${blockNumber} (requestID ${requestID})`,
-      );
-    },
-  );
-  oracle.on('ResultcallbackAddress', async (requestID, success, result, eventData) => {
-    const blockNumber = eventData.log.blockNumber;
-    console.log(`${await currentTime()} - Fulfilled eaddress decrypt on block ${blockNumber} (requestID ${requestID})`);
+    console.log(`${await currentTime()} - Fulfilled decrypt on block ${blockNumber} (requestID ${requestID})`);
   });
 };
 
@@ -138,265 +62,44 @@ export const awaitAllDecryptionResults = async (): Promise<void> => {
 
 const getAlreadyFulfilledDecryptions = async (): Promise<[bigint]> => {
   let results = [];
-  const eventDecryptionResultBool = await oracle.filters.ResultCallbackBool().getTopicFilter();
-  const filterDecryptionResultBool = {
+  const eventDecryptionResult = await oracle.filters.ResultCallback().getTopicFilter();
+  const filterDecryptionResult = {
     address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
     fromBlock: firstBlockListening,
     toBlock: 'latest',
-    topics: eventDecryptionResultBool,
+    topics: eventDecryptionResult,
   };
-  const pastResultsEbool = await ethers.provider.getLogs(filterDecryptionResultBool);
-  results = results.concat(pastResultsEbool.map((result) => ifaceResultCallbackBool.parseLog(result).args[0]));
-
-  const eventDecryptionResultEUint4 = await oracle.filters.ResultCallbackUint4().getTopicFilter();
-  const filterDecryptionResultUint4 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEUint4,
-  };
-  const pastResultsEuint4 = await ethers.provider.getLogs(filterDecryptionResultUint4);
-  results = results.concat(pastResultsEuint4.map((result) => ifaceResultCallbackUint4.parseLog(result).args[0]));
-
-  const eventDecryptionResultEUint8 = await oracle.filters.ResultCallbackUint8().getTopicFilter();
-  const filterDecryptionResultUint8 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEUint8,
-  };
-  const pastResultsEuint8 = await ethers.provider.getLogs(filterDecryptionResultUint8);
-  results = results.concat(pastResultsEuint8.map((result) => ifaceResultCallbackUint8.parseLog(result).args[0]));
-
-  const eventDecryptionResultEUint16 = await oracle.filters.ResultCallbackUint16().getTopicFilter();
-  const filterDecryptionResultUint16 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEUint16,
-  };
-  const pastResultsEuint16 = await ethers.provider.getLogs(filterDecryptionResultUint16);
-  results = results.concat(pastResultsEuint16.map((result) => ifaceResultCallbackUint16.parseLog(result).args[0]));
-
-  const eventDecryptionResultEUint32 = await oracle.filters.ResultCallbackUint32().getTopicFilter();
-  const filterDecryptionResultUint32 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEUint32,
-  };
-  const pastResultsEuint32 = await ethers.provider.getLogs(filterDecryptionResultUint32);
-  results = results.concat(pastResultsEuint32.map((result) => ifaceResultCallbackUint32.parseLog(result).args[0]));
-
-  const eventDecryptionResultEUint64 = await oracle.filters.ResultCallbackUint64().getTopicFilter();
-  const filterDecryptionResultUint64 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEUint64,
-  };
-  const pastResultsEuint64 = await ethers.provider.getLogs(filterDecryptionResultUint64);
-  results = results.concat(pastResultsEuint64.map((result) => ifaceResultCallbackUint64.parseLog(result).args[0]));
-
-  const eventDecryptionResultEAddress = await oracle.filters.ResultcallbackAddress().getTopicFilter();
-  const filterDecryptionResultAddress = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionResultEAddress,
-  };
-  const pastResultsEaddress = await ethers.provider.getLogs(filterDecryptionResultAddress);
-  results = results.concat(pastResultsEaddress.map((result) => ifaceResultcallbackAddress.parseLog(result).args[0]));
+  const pastResults = await ethers.provider.getLogs(filterDecryptionResult);
+  results = results.concat(pastResults.map((result) => ifaceResultCallback.parseLog(result).args[0]));
 
   return results;
 };
 
 const fulfillAllPastRequestsIds = async (mocked: boolean) => {
-  const eventDecryptionEBool = await oracle.filters.EventDecryptionEBool().getTopicFilter();
+  const eventDecryption = await oracle.filters.EventDecryption().getTopicFilter();
   const results = await getAlreadyFulfilledDecryptions();
-  const filterDecryptionEBool = {
+  const filterDecryption = {
     address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
     fromBlock: firstBlockListening,
     toBlock: 'latest',
-    topics: eventDecryptionEBool,
+    topics: eventDecryption,
   };
-  const pastRequestsEbool = await ethers.provider.getLogs(filterDecryptionEBool);
-  for (const request of pastRequestsEbool) {
-    const event = ifaceEventDecryptionEBool.parseLog(request);
+  const pastRequests = await ethers.provider.getLogs(filterDecryption);
+  for (const request of pastRequests) {
+    const event = ifaceEventDecryption.parseLog(request);
     const requestID = event.args[0];
     const cts = event.args[1];
+    const handles = cts.map((ct) => ct[0]);
+    const typesEnum = cts.map((ct) => ct[1]);
     const msgValue = event.args[4];
     if (!results.includes(requestID)) {
       // if request is not already fulfilled
       if (mocked) {
         // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestBool(
-          requestID,
-          cts.map((value) => value === 1n),
-          { value: msgValue },
-        );
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEUint4 = await oracle.filters.EventDecryptionEUint4().getTopicFilter();
-  const filterDecryptionEUint4 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEUint4,
-  };
-  const pastRequestsEUint4 = await ethers.provider.getLogs(filterDecryptionEUint4);
-  for (const request of pastRequestsEUint4) {
-    const event = ifaceEventDecryptionEUint4.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestUint4(requestID, [...cts], { value: msgValue });
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEUint8 = await oracle.filters.EventDecryptionEUint8().getTopicFilter();
-  const filterDecryptionEUint8 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEUint8,
-  };
-  const pastRequestsEUint8 = await ethers.provider.getLogs(filterDecryptionEUint8);
-  for (const request of pastRequestsEUint8) {
-    const event = ifaceEventDecryptionEUint8.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestUint8(requestID, [...cts], { value: msgValue });
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEUint16 = await oracle.filters.EventDecryptionEUint16().getTopicFilter();
-  const filterDecryptionEUint16 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEUint16,
-  };
-  const pastRequestsEUint16 = await ethers.provider.getLogs(filterDecryptionEUint16);
-  for (const request of pastRequestsEUint16) {
-    const event = ifaceEventDecryptionEUint16.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestUint16(requestID, [...cts], { value: msgValue });
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEUint32 = await oracle.filters.EventDecryptionEUint32().getTopicFilter();
-  const filterDecryptionEUint32 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEUint32,
-  };
-  const pastRequestsEUint32 = await ethers.provider.getLogs(filterDecryptionEUint32);
-  for (const request of pastRequestsEUint32) {
-    const event = ifaceEventDecryptionEUint32.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestUint32(requestID, [...cts], { value: msgValue });
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEUint64 = await oracle.filters.EventDecryptionEUint64().getTopicFilter();
-  const filterDecryptionEUint64 = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEUint64,
-  };
-  const pastRequestsEUint64 = await ethers.provider.getLogs(filterDecryptionEUint64);
-  for (const request of pastRequestsEUint64) {
-    const event = ifaceEventDecryptionEUint64.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestUint64(requestID, [...cts], { value: msgValue });
-        await tx.wait();
-      } else {
-        // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx
-        await waitNBlocks(1);
-        await fulfillAllPastRequestsIds(mocked);
-      }
-    }
-  }
-
-  const eventDecryptionEAddress = await oracle.filters.EventDecryptionEAddress().getTopicFilter();
-  const filterDecryptionEAddress = {
-    address: process.env.ORACLE_CONTRACT_PREDEPLOY_ADDRESS,
-    fromBlock: firstBlockListening,
-    toBlock: 'latest',
-    topics: eventDecryptionEAddress,
-  };
-  const pastRequestsEAddress = await ethers.provider.getLogs(filterDecryptionEAddress);
-  for (const request of pastRequestsEAddress) {
-    const event = ifaceEventDecryptionEAddress.parseLog(request);
-    const requestID = event.args[0];
-    const cts = event.args[1];
-    const msgValue = event.args[4];
-    if (!results.includes(requestID)) {
-      // if request is not already fulfilled
-      if (mocked) {
-        // in mocked mode, we trigger the decryption fulfillment manually
-        const tx = await oracle.connect(relayer).fulfillRequestAddress(requestID, [...cts], { value: msgValue });
+        const types = typesEnum.map((num) => CiphertextType[num]);
+        const values = handles.map((handle, index) => (typesEnum[index] === 7n ? handle.toString(16) : handle));
+        const calldata = ethers.AbiCoder.defaultAbiCoder().encode(types, values);
+        const tx = await oracle.connect(relayer).fulfillRequest(requestID, calldata, { value: msgValue });
         await tx.wait();
       } else {
         // in fhEVM mode we must wait until the oracle service relayer submits the decryption fulfillment tx

--- a/test/oracleDecrypt/testAsyncDecrypt.ts
+++ b/test/oracleDecrypt/testAsyncDecrypt.ts
@@ -198,7 +198,7 @@ describe('TestAsyncDecrypt', function () {
     await tx2.wait();
     await awaitAllDecryptionResults();
     const y = await this.contract.yUint64();
-    expect(y).to.equal(64);
+    expect(y).to.equal(18446744073709551600n);
   });
 
   it('test async decrypt FAKE uint64', async function () {
@@ -269,5 +269,27 @@ describe('TestAsyncDecrypt', function () {
       }
       expect(waitTime >= 15000).to.be.true;
     }
+  });
+
+  it('test async decrypt mixed', async function () {
+    const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
+    const contract2 = await contractFactory.connect(this.signers.alice).deploy();
+    const tx2 = await contract2.connect(this.signers.carol).requestMixed(5, 15, { gasLimit: 1_000_000 });
+    await tx2.wait();
+    await awaitAllDecryptionResults();
+    let yB = await contract2.yBool();
+    expect(yB).to.equal(true);
+    let y = await contract2.yUint4();
+    expect(y).to.equal(4);
+    y = await contract2.yUint8();
+    expect(y).to.equal(42);
+    y = await contract2.yUint16();
+    expect(y).to.equal(16);
+    let yAdd = await contract2.yAddress();
+    expect(yAdd).to.equal('0x8ba1f109551bD432803012645Ac136ddd64DBA72');
+    y = await contract2.yUint32();
+    expect(y).to.equal(52); // 5+15+32
+    y = await contract2.yUint64();
+    expect(y).to.equal(18446744073709551600n);
   });
 });

--- a/test/oracleDecrypt/testAsyncDecrypt.ts
+++ b/test/oracleDecrypt/testAsyncDecrypt.ts
@@ -36,8 +36,19 @@ describe('TestAsyncDecrypt', function () {
       );
     } else {
       // fhevm-mode
-      const tx = await this.contract.connect(this.signers.carol).requestBoolAboveDelay({ gasLimit: 1_000_000 });
-      await expect(tx.wait()).to.throw;
+      const txObject = await this.contract.requestBoolAboveDelay.populateTransaction({ gasLimit: 1_000_000 });
+      const tx = await this.signers.carol.sendTransaction(txObject);
+      let receipt = null;
+      let waitTime = 0;
+      while (receipt === null && waitTime < 15000) {
+        receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        if (receipt === null) {
+          console.log('Trying again to fetch txn receipt....');
+          await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait for 5 seconds
+          waitTime += 5000;
+        }
+      }
+      receipt === null ? expect(waitTime >= 15000).to.be.true : expect(receipt!.status).to.equal(0);
     }
   });
 
@@ -55,9 +66,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE bool', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeBool.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeBool.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -69,7 +78,7 @@ describe('TestAsyncDecrypt', function () {
           waitTime += 5000;
         }
       }
-      expect(waitTime >= 15000).to.be.true;
+      receipt === null ? expect(waitTime >= 15000).to.be.true : expect(receipt!.status).to.equal(0);
     }
   });
 
@@ -87,9 +96,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE uint4', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeUint4.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeUint4.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -116,9 +123,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE uint8', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeUint8.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeUint8.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -145,9 +150,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE uint16', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeUint16.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeUint16.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -174,9 +177,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE uint32', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeUint32.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeUint32.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -203,9 +204,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE uint64', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeUint64.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeUint64.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;
@@ -256,9 +255,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt FAKE address', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode
-      const txObject = await this.contract
-        .connect(this.signers.carol)
-        .requestFakeAddress.populateTransaction({ gasLimit: 5_000_000 });
+      const txObject = await this.contract.requestFakeAddress.populateTransaction({ gasLimit: 5_000_000 });
       const tx = await this.signers.carol.sendTransaction(txObject);
       let receipt = null;
       let waitTime = 0;

--- a/test/oracleDecrypt/testAsyncDecrypt.ts
+++ b/test/oracleDecrypt/testAsyncDecrypt.ts
@@ -238,20 +238,6 @@ describe('TestAsyncDecrypt', function () {
     expect(y2).to.equal('0xf48b8840387ba3809DAE990c930F3b4766A86ca3');
   });
 
-  it('test async decrypt several uint64s with duplicates', async function () {
-    const tx2 = await this.contract
-      .connect(this.signers.carol)
-      .requestSeveralUint64WithDuplicates({ gasLimit: 1_000_000 });
-    await tx2.wait();
-    await awaitAllDecryptionResults();
-    const y = await this.contract.yUint64();
-    const y2 = await this.contract.yUint64_2();
-    const y3 = await this.contract.yUint64_3();
-    expect(y).to.equal(64);
-    expect(y2).to.equal(76575465786);
-    expect(y3).to.equal(6400);
-  });
-
   it('test async decrypt FAKE address', async function () {
     if (network.name !== 'hardhat') {
       // only in fhevm mode


### PR DESCRIPTION
This new API is cleaner and more concise (no more almost duplicated events for each types of ciphertexts) and allows users to request decryption of different types in a single `requestDecryption` transaction.
Work in Progress status: DONE
1st commit ready : all the solidity code is done and ready for review already ✅
2nd commit will come soon for the JS part (tests+mocked mode). ✅ NOW DONE! 

For the solidity part, discussion and approval needed on this:
I had to decouple the storage of honestly obtained ciphertext in privileged storage - via the `OraclePredeploy:approveEUintXXX` functions, called inside the `Oracle:toCiphertext` internal library functions -  from the `requestDecryption` in order to be able to send ciphertexts of different types in a single `requestDecryption`call. This will add some complexity in the oracle service as we will now have to loop on all stored array of handles in the `verifiedEUintXXXs` mappings (for a fixed counter/key index and type) until we find at least one handle which comes from a honestly obtained ciphertext, i.e with corresponding ciphertext in privileged storage. Also security model guarantees are not 100% the same - in theory a user could approve a honestly obtained handle in a first transaction and (some other malicious user) request decryption in a later transaction even with non-honestly obtained identical handle if counter did not change i.e if no `requestDecryption` happened meanwhile- but risk is inexistent as long as user ensures there is no call to an `approveEUintXXX` function unless he wanted to request a decryption in the same transaction. In summary there should be no risk unless the smart contract of the dApp is malicious.

Also, it is now the responsibility of the relayer to do the correct abi-encoding of the concatenated decrypted variables and pass them as a single bytes array argument to the `fulfillRequest` function of the `OraclePredeploy`