### PR TITLE
Fix few codegen errors to allow solidity compilation in Mock mode.

### DIFF
--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -1312,7 +1312,7 @@ library Impl {
       key = hex"0123456789ABCDEF";
   }
 
-  function verify(einput inputHandle,
+  function verify(bytes32 inputHandle,
         bytes memory inputProof,
         uint8 toType) internal returns (uint256 result) {
       // TODO: fix implementation

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -1378,6 +1378,23 @@ library Impl {
     // much as this is a mock).
     result = rand(randType) % upperBound;
   }
+
+  function allowTransient(uint256 handle, address account) internal {
+    // Not yet implemented
+  }
+
+  function allow(uint256 handle, address account) internal {
+    // Not yet implemented
+  }
+
+  function cleanTransientStorage() internal {
+    // Not yet implemented
+  }
+
+  function isAllowed(uint256 handle, address account) internal view returns (bool) {
+    // Not yet implemented
+    return true;
+  }
 `);
 
   res.push('}\n');

--- a/codegen/templates.ts
+++ b/codegen/templates.ts
@@ -1302,10 +1302,6 @@ library Impl {
       result = (control == 1) ? ifTrue : ifFalse;
   }
 
-  function select(uint256 control, uint256 ifTrue, uint256 ifFalse) internal pure returns (uint256 result) {
-      result = (control == 1) ? ifTrue : ifFalse;
-  }
-
   function optReq(uint256 ciphertext) internal view {
       this; // silence state mutability warning
       require(ciphertext == 1, "transaction execution reverted");


### PR DESCRIPTION
### Issue:
- ```Impl.sol``` does not compile in mock mode due to `select` function declared twice.

```
DeclarationError: Function with same name and parameter types defined twice.
   --> fhevm/mocks/Impl.sol:122:5:
    |
122 |     function select(uint256 control, uint256 ifTrue, uint256 ifFalse) internal pure returns (uint256 result) {
    |     ^ (Relevant source part starts here and spans across multiple lines).
Note: Other declaration is here:
   --> fhevm/mocks/Impl.sol:126:5:
    |
126 |     function select(uint256 control, uint256 ifTrue, uint256 ifFalse) internal pure returns (uint256 result) {
    |     ^ (Relevant source part starts here and spans across multiple lines).
```
- ```Impl.sol``` does not compile in mock mode due to implicit conversion error in `verify` function
- ```TFHE.sol``` does not compile in mock mode due to missing functions in `Impl.sol`

### Solution:
- Remove the duplicate declaration in ```codegen/template.ts```
- Change `verify` from `einput` to `bytes32`
- Add dummy ineffective missing functions in `Impl.sol` : allow + clearTranscientStorage