### PR TITLE
chore: fix small typo in the documentation about re-encryption

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
+          config-file: "mlc_config.json"

--- a/docs/fundamentals/decrypt.md
+++ b/docs/fundamentals/decrypt.md
@@ -19,9 +19,9 @@ You can read about an actual implemention in [our decryption guide](../guides/de
 
 Reencryption is performed on the client side by calling the gateway service using the [fhevmjs](https://github.com/zama-ai/fhevmjs/) library. To do this, you need to provide a view function that returns the ciphertext to be reencrypted.
 
-1. The dApp retrieves the ciphertext from the view function (e.g., balanceOf).
+1. The dApp retrieves the handle from the view function (e.g., balanceOf).
 2. The dApp generates a keypair for the user and requests the user to sign the public key.
-3. The dApp calls the gateway, providing the ciphertext, public key, user address, contract address, and the user's signature.
+3. The dApp calls the gateway, providing the handle, public key, user address, contract address, and the user's signature.
 4. The dApp decrypts the received value with the private key.
 
 You can read [our guide explaining how to use it](../guides/reencryption.md).

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,1 @@
+{"aliveStatusCodes": [429, 200]}


### PR DESCRIPTION
Following a discussion at the office with @leventdem we noticed a small typo in the documentation. Indeed even in the case of re-encryption the gateway receives the handle and not the cipher-text.

c.f. https://github.com/zama-ai/fhevm/blob/914699f9695c6f5205ec011be1155189f8abba5b/test/encryptedERC20/EncryptedERC20.ts#L76-L91