### PR TITLE
feat: added aclAddress in EIP712 struct of KMSVerifier

### DIFF
--- a/gateway/GatewayContract.sol
+++ b/gateway/GatewayContract.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "../lib/KMSVerifierAddress.sol";
+import "../lib/ACLAddress.sol";
 import "./IKMSVerifier.sol";
 
 contract GatewayContract is UUPSUpgradeable, Ownable2StepUpgradeable {
@@ -19,6 +20,7 @@ contract GatewayContract is UUPSUpgradeable, Ownable2StepUpgradeable {
     uint256 private constant PATCH_VERSION = 0;
 
     IKMSVerifier private constant kmsVerifier = IKMSVerifier(kmsVerifierAdd);
+    address private constant aclAddress = aclAdd;
 
     uint256 private constant MAX_DELAY = 1 days;
 
@@ -176,7 +178,7 @@ contract GatewayContract is UUPSUpgradeable, Ownable2StepUpgradeable {
     ) external payable virtual onlyRelayer {
         GatewayContractStorage storage $ = _getGatewayContractStorage();
         require(
-            kmsVerifier.verifySignatures($.decryptionRequests[requestID].cts, decryptedCts, signatures),
+            kmsVerifier.verifySignatures(aclAddress, $.decryptionRequests[requestID].cts, decryptedCts, signatures),
             "KMS signature verification failed"
         );
         require(!$.isFulfilled[requestID], "Request is already fulfilled");

--- a/gateway/IKMSVerifier.sol
+++ b/gateway/IKMSVerifier.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 
 interface IKMSVerifier {
     function verifySignatures(
+        address aclAddress,
         uint256[] memory handlesList,
         bytes memory decryptedResult,
         bytes[] memory signatures

--- a/gateway/lib/Gateway.sol
+++ b/gateway/lib/Gateway.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.24;
 import "./GatewayContractAddress.sol";
 import "../IKMSVerifier.sol";
 import "../../lib/Impl.sol";
+import "../../lib/ACLAddress.sol";
 
 interface IGatewayContract {
     function requestDecryption(
@@ -106,7 +107,7 @@ library Gateway {
             calldatacopy(add(decryptedResult, 0x20), start, length) // Copy the relevant part of calldata to decryptedResult memory
         }
         FHEVMConfig.FHEVMConfigStruct storage $ = Impl.getFHEVMConfig();
-        return IKMSVerifier($.KMSVerifierAddress).verifySignatures(handlesList, decryptedResult, signatures);
+        return IKMSVerifier($.KMSVerifierAddress).verifySignatures(aclAdd, handlesList, decryptedResult, signatures);
     }
 
     function getSignedDataLength(uint256[] memory handlesList) private pure returns (uint256) {

--- a/lib/KMSVerifier.sol
+++ b/lib/KMSVerifier.sol
@@ -14,11 +14,13 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 /// @dev The contract uses OpenZeppelin's EIP712Upgradeable for cryptographic operations
 contract KMSVerifier is UUPSUpgradeable, Ownable2StepUpgradeable, EIP712Upgradeable {
     struct DecryptionResult {
+        address aclAddress;
         uint256[] handlesList;
         bytes decryptedResult;
     }
 
-    string private constant DECRYPTIONRESULT_TYPE = "DecryptionResult(uint256[] handlesList,bytes decryptedResult)";
+    string private constant DECRYPTIONRESULT_TYPE =
+        "DecryptionResult(address aclAddress,uint256[] handlesList,bytes decryptedResult)";
     bytes32 private constant DECRYPTIONRESULT_TYPE_HASH = keccak256(bytes(DECRYPTIONRESULT_TYPE));
 
     /// @notice Name of the contract
@@ -111,6 +113,7 @@ contract KMSVerifier is UUPSUpgradeable, Ownable2StepUpgradeable, EIP712Upgradea
                 keccak256(
                     abi.encode(
                         DECRYPTIONRESULT_TYPE_HASH,
+                        decRes.aclAddress,
                         keccak256(abi.encodePacked(decRes.handlesList)),
                         keccak256(decRes.decryptedResult)
                     )
@@ -157,11 +160,13 @@ contract KMSVerifier is UUPSUpgradeable, Ownable2StepUpgradeable, EIP712Upgradea
     /// @param signatures An array of signatures to verify
     /// @return true if enough provided signatures are valid, false otherwise
     function verifySignatures(
+        address aclAddress,
         uint256[] memory handlesList,
         bytes memory decryptedResult,
         bytes[] memory signatures
     ) public virtual returns (bool) {
         DecryptionResult memory decRes;
+        decRes.aclAddress = aclAddress;
         decRes.handlesList = handlesList;
         decRes.decryptedResult = decryptedResult;
         bytes32 message = hashDecryptionResult(decRes);

--- a/test/asyncDecrypt.ts
+++ b/test/asyncDecrypt.ts
@@ -200,6 +200,10 @@ async function kmsSign(handlesList: bigint[], decryptedResult: string, kmsSigner
   const types = {
     DecryptionResult: [
       {
+        name: 'aclAddress',
+        type: 'address',
+      },
+      {
         name: 'handlesList',
         type: 'uint256[]',
       },
@@ -209,8 +213,8 @@ async function kmsSign(handlesList: bigint[], decryptedResult: string, kmsSigner
       },
     ],
   };
-
   const message = {
+    aclAddress: aclAdd,
     handlesList: handlesList,
     decryptedResult: decryptedResult,
   };


### PR DESCRIPTION
First commit adds aclAddress in the EIP712 struct of KMSVerifier. This was requested by @immortal-tofu to have a single KMSVerifier shared by multiple coprocessors on the same chain.