### PR TITLE
fix: Use #!/usr/bin/env bash rather than #!/bin/bash

### DIFF
--- a/ci/scripts/prepare_fhe_keys_ci.sh
+++ b/ci/scripts/prepare_fhe_keys_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 

--- a/ci/scripts/prepare_fhe_keys_for_e2e_test.sh
+++ b/ci/scripts/prepare_fhe_keys_for_e2e_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 
@@ -14,7 +14,7 @@ KEYS_FULL_PATH=$1
 mkdir -p $NETWORK_KEYS_PUBLIC_PATH
 
 MANDATORY_KEYS_LIST=('pks')
- 
+
 echo "check folder $KEYS_FULL_PATH"
 for key in "${MANDATORY_KEYS_LIST[@]}"
     do

--- a/ci/scripts/run_ERC20.sh
+++ b/ci/scripts/run_ERC20.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# This script execute a python script within a ready-to-use docker image with all the required python modules. 
+# This script execute a python script within a ready-to-use docker image with all the required python modules.
 # The script takes two arguments:
 #   1. The private key of the main account which has already funds.
 #   2. (Optional) The node address (default: http://host.docker.internal:8545)

--- a/ci/scripts/run_ERC20_ci_test.sh
+++ b/ci/scripts/run_ERC20_ci_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script exports an Ethereum private key from an evmos node and uses it to run a Python script.
 # The script takes two arguments:

--- a/ci/scripts/run_ERC20_e2e_test.sh
+++ b/ci/scripts/run_ERC20_e2e_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script exports an Ethereum private key from an evmos node and uses it to run a Python script.
 # The script takes two arguments:

--- a/launch-fhevm.sh
+++ b/launch-fhevm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PRIVATE_KEY_GATEWAY_DEPLOYER=$(grep PRIVATE_KEY_GATEWAY_DEPLOYER .env | cut -d '"' -f 2)
 
@@ -15,7 +15,7 @@ docker run -d -i -p 8545:8545 --rm --name fhevm \
   -e ORACLE_CONTRACT_PREDEPLOY_ADDRESS="$ORACLE_CONTRACT_PREDEPLOY_ADDRESS" \
   -e TFHE_EXECUTOR_CONTRACT_ADDRESS="$TFHE_EXECUTOR_CONTRACT_ADDRESS" \
   ghcr.io/zama-ai/ethermint-dev-node:v0.5.0-1
-  
+
 sleep 10
 
 npx hardhat task:computeACLAddress

--- a/scripts/faucet.sh
+++ b/scripts/faucet.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Alice
 npm run fhevm:faucet
-sleep 8 
+sleep 8
 npm run fhevm:faucet:bob
 sleep 8
 npm run fhevm:faucet:carol

--- a/setup-local-fhevm.sh
+++ b/setup-local-fhevm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Assumes the following:
 # 1. A local and **fresh** fhEVM node is already running.


### PR DESCRIPTION
As an act of selfless kindness to non FHS-compliant OSes (like NixOS)

This should be strictly more portable than the current shebang