### PR TITLE
chore: awaitDeployment

### DIFF
--- a/test/gatewayDecrypt/testAsyncDecrypt.ts
+++ b/test/gatewayDecrypt/testAsyncDecrypt.ts
@@ -29,6 +29,7 @@ describe('TestAsyncDecrypt', function () {
   beforeEach(async function () {
     const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
     this.contract = await contractFactory.connect(this.signers.alice).deploy();
+    await this.contract.waitForDeployment();
     this.contractAddress = await this.contract.getAddress();
     this.instances = await createInstances(this.signers);
   });
@@ -88,6 +89,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt bool trustless', async function () {
     const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
     const contract2 = await contractFactory.connect(this.signers.alice).deploy();
+    await contract2.waitForDeployment();
     const tx2 = await contract2.requestBoolTrustless({ gasLimit: 5_000_000 });
     await tx2.wait();
     await awaitAllDecryptionResults();
@@ -503,6 +505,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt ebytes256 non-trivial trustless', async function () {
     const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
     const contract2 = await contractFactory.connect(this.signers.alice).deploy();
+    await contract2.waitForDeployment();
     const inputAlice = this.instances.alice.createEncryptedInput(
       await contract2.getAddress(),
       this.signers.alice.address,
@@ -523,6 +526,7 @@ describe('TestAsyncDecrypt', function () {
   it('test async decrypt mixed with ebytes256 trustless', async function () {
     const contractFactory = await ethers.getContractFactory('TestAsyncDecrypt');
     const contract2 = await contractFactory.connect(this.signers.alice).deploy();
+    await contract2.waitForDeployment();
     const inputAlice = this.instances.alice.createEncryptedInput(
       await contract2.getAddress(),
       this.signers.alice.address,

--- a/test/reencryption/reencryption.ts
+++ b/test/reencryption/reencryption.ts
@@ -13,6 +13,7 @@ describe('Reencryption', function () {
     const contractFactory = await ethers.getContractFactory('Reencrypt');
 
     this.contract = await contractFactory.connect(this.signers.alice).deploy();
+    await this.contract.waitForDeployment();
     this.contractAddress = await this.contract.getAddress();
     this.instances = await createInstances(this.signers);
   });


### PR DESCRIPTION
This solves the weird issue where only carol could deploy the TestAsyncDecrypt contract and avoid other similar issues in other tests.