### PR TITLE
test: use chai to.be.rejectedWith & fix ts errors

### DIFF
--- a/test/encryptedERC20/EncryptedERC20.ts
+++ b/test/encryptedERC20/EncryptedERC20.ts
@@ -102,42 +102,34 @@ describe('EncryptedERC20', function () {
     expect(balanceBob).to.equal(1337);
 
     // on the other hand, Bob should be unable to read Alice's balance
-    try {
-      await this.instances.bob.reencrypt(
+    await expect(
+      this.instances.bob.reencrypt(
         balanceHandleAlice,
         privateKeyBob,
         publicKeyBob,
         signatureBob.replace('0x', ''),
         this.contractAddress,
         this.signers.bob.address,
-      );
-      expect.fail('Expected an error to be thrown - Bob should not be able to reencrypt Alice balance');
-    } catch (error) {
-      expect(error.message).to.equal('User is not authorized to reencrypt this handle!');
-    }
+      ),
+    ).to.be.rejectedWith('User is not authorized to reencrypt this handle!');
 
     // and should be impossible to call reencrypt if contractAddress === userAddress
-    try {
-      const eip712b = this.instances.alice.createEIP712(publicKeyAlice, this.signers.alice.address);
-      const signatureAliceb = await this.signers.alice.signTypedData(
-        eip712b.domain,
-        { Reencrypt: eip712b.types.Reencrypt },
-        eip712b.message,
-      );
-      await this.instances.alice.reencrypt(
+    const eip712b = this.instances.alice.createEIP712(publicKeyAlice, this.signers.alice.address);
+    const signatureAliceb = await this.signers.alice.signTypedData(
+      eip712b.domain,
+      { Reencrypt: eip712b.types.Reencrypt },
+      eip712b.message,
+    );
+    await expect(
+      this.instances.alice.reencrypt(
         balanceHandleAlice,
         privateKeyAlice,
         publicKeyAlice,
         signatureAliceb.replace('0x', ''),
         this.signers.alice.address,
         this.signers.alice.address,
-      );
-      expect.fail('Expected an error to be thrown - userAddress and contractAddress cannot be equal');
-    } catch (error) {
-      expect(error.message).to.equal(
-        'userAddress should not be equal to contractAddress when requesting reencryption!',
-      );
-    }
+      ),
+    ).to.be.rejectedWith('userAddress should not be equal to contractAddress when requesting reencryption!');
   });
 
   it('should not transfer tokens between two users', async function () {

--- a/test/reencryption/reencryption.ts
+++ b/test/reencryption/reencryption.ts
@@ -38,49 +38,41 @@ describe('Reencryption', function () {
     expect(decryptedValue).to.equal(1);
 
     // on the other hand, Bob should be unable to read Alice's balance
-    try {
-      const { publicKey: publicKeyBob, privateKey: privateKeyBob } = this.instances.bob.generateKeypair();
-      const eip712Bob = this.instances.bob.createEIP712(publicKeyBob, this.contractAddress);
-      const signatureBob = await this.signers.bob.signTypedData(
-        eip712Bob.domain,
-        { Reencrypt: eip712Bob.types.Reencrypt },
-        eip712Bob.message,
-      );
-      await this.instances.bob.reencrypt(
+    const { publicKey: publicKeyBob, privateKey: privateKeyBob } = this.instances.bob.generateKeypair();
+    const eip712Bob = this.instances.bob.createEIP712(publicKeyBob, this.contractAddress);
+    const signatureBob = await this.signers.bob.signTypedData(
+      eip712Bob.domain,
+      { Reencrypt: eip712Bob.types.Reencrypt },
+      eip712Bob.message,
+    );
+    await expect(
+      this.instances.bob.reencrypt(
         handle,
         privateKeyBob,
         publicKeyBob,
         signatureBob.replace('0x', ''),
         this.contractAddress,
         this.signers.bob.address,
-      );
-      expect.fail('Expected an error to be thrown - Bob should not be able to reencrypt Alice balance');
-    } catch (error) {
-      expect(error.message).to.equal('User is not authorized to reencrypt this handle!');
-    }
+      ),
+    ).to.be.rejectedWith('User is not authorized to reencrypt this handle!');
 
     // and should be impossible to call reencrypt if contractAddress === userAddress
-    try {
-      const eip712b = this.instances.alice.createEIP712(publicKey, this.signers.alice.address);
-      const signatureAliceb = await this.signers.alice.signTypedData(
-        eip712b.domain,
-        { Reencrypt: eip712b.types.Reencrypt },
-        eip712b.message,
-      );
-      await this.instances.alice.reencrypt(
+    const eip712b = this.instances.alice.createEIP712(publicKey, this.signers.alice.address);
+    const signatureAliceb = await this.signers.alice.signTypedData(
+      eip712b.domain,
+      { Reencrypt: eip712b.types.Reencrypt },
+      eip712b.message,
+    );
+    await expect(
+      this.instances.alice.reencrypt(
         handle,
         privateKey,
         publicKey,
         signatureAliceb.replace('0x', ''),
         this.signers.alice.address,
         this.signers.alice.address,
-      );
-      expect.fail('Expected an error to be thrown - userAddress and contractAddress cannot be equal');
-    } catch (error) {
-      expect(error.message).to.equal(
-        'userAddress should not be equal to contractAddress when requesting reencryption!',
-      );
-    }
+      ),
+    ).to.be.rejectedWith('userAddress should not be equal to contractAddress when requesting reencryption!');
   });
 
   it('test reencrypt euint4', async function () {


### PR DESCRIPTION
Fixing typescript errors and using specific `should.be.rejectedWith` chai syntax