### PR TITLE
feat: add default configs for Gateway and FHEVM

### DIFF
--- a/config/ZamaFHEVMConfig.sol
+++ b/config/ZamaFHEVMConfig.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHEVMConfig, TFHE} from "../lib/TFHE.sol";
+
+/**
+ * @title   ZamaFHEVMConfig.
+ * @notice  This library returns the TFHE config for different networks
+ *          with the contract addresses for
+ *          (1) ACL, (2) TFHEExecutor, (3) FHEPayment, (4) KMSVerifier,
+ *          which are deployed & maintained by Zama.
+ */
+library ZamaFHEVMConfig {
+    function getMockConfig() internal pure returns (FHEVMConfig.FHEVMConfigStruct memory) {
+        return
+            FHEVMConfig.FHEVMConfigStruct({
+                ACLAddress: 0x339EcE85B9E11a3A3AA557582784a15d7F82AAf2,
+                TFHEExecutorAddress: 0x596E6682c72946AF006B27C131793F2b62527A4b,
+                FHEPaymentAddress: 0x6d5A11aC509C707c00bc3A0a113ACcC26c532547,
+                KMSVerifierAddress: 0x208De73316E44722e16f6dDFF40881A3e4F86104
+            });
+    }
+
+    function getSepoliaConfig() internal pure returns (FHEVMConfig.FHEVMConfigStruct memory) {
+        /// TODO
+    }
+
+    function getEthereumConfig() internal pure returns (FHEVMConfig.FHEVMConfigStruct memory) {
+        /// TODO
+    }
+}
+
+/**
+ * @title   MockZamaFHEVMConfig.
+ * @dev     This contract can be inherited by a contract wishing to use these contracts on the mock
+ *          environment provided by Zama.
+ *          Other providers may offer similar contracts deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract MockZamaFHEVMConfig {
+    constructor() {
+        TFHE.setFHEVM(ZamaFHEVMConfig.getMockConfig());
+    }
+}
+
+/**
+ * @title   SepoliaZamaFHEVMConfig.
+ * @dev     This contract can be inherited by a contract wishing to use the FHEVM contracts provided by Zama
+ *          on the Sepolia network (chainId = 11155111).
+ *          Other providers may offer similar contracts deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract SepoliaZamaFHEVMConfig {
+    constructor() {
+        TFHE.setFHEVM(ZamaFHEVMConfig.getSepoliaConfig());
+    }
+}
+
+/**
+ * @title   EthereumZamaFHEVMConfig.
+ * @dev     This contract can be inherited by a contract wishing to use the FHEVM contracts provided by Zama
+ *          on the Ethereum (mainnet) network (chainId = 1).
+ *          Other providers may offer similar contracts deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract EthereumZamaFHEVMConfig {
+    constructor() {
+        TFHE.setFHEVM(ZamaFHEVMConfig.getEthereumConfig());
+    }
+}

--- a/config/ZamaGatewayConfig.sol
+++ b/config/ZamaGatewayConfig.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Gateway} from "../gateway/lib/Gateway.sol";
+
+/**
+ * @title   ZamaGatewayConfig.
+ * @notice  This library returns the Gateway config for different networks
+ *          with the address of the Gateway contract, which is
+ *          deployed & maintained by Zama.
+ */
+library ZamaGatewayConfig {
+    function getMockConfig() internal pure returns (address) {
+        return 0x096b4679d45fB675d4e2c1E4565009Cec99A12B1;
+    }
+
+    function getSepoliaConfig() internal pure returns (address) {
+        /// TODO
+    }
+
+    function getEthereumConfig() internal pure returns (address) {
+        /// TODO
+    }
+}
+
+/**
+ * @title   MockZamaGatewayConfig
+ * @dev     This contract can be inherited by a contract wishing to use the Gateway service
+ *          on the mock environment provided by Zama.
+ *          Other providers may offer other Gateways that are deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract MockZamaGatewayConfig {
+    constructor() {
+        Gateway.setGateway(ZamaGatewayConfig.getMockConfig());
+    }
+}
+
+/**
+ * @title   SepoliaZamaGatewayConfig
+ * @dev     This contract can be inherited by a contract wishing to use the Gateway service
+ *          provided by Zama on the Sepolia network (chainId = 11155111).
+ *          Other providers may offer other Gateways that are deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract SepoliaZamaGatewayConfig {
+    constructor() {
+        Gateway.setGateway(ZamaGatewayConfig.getSepoliaConfig());
+    }
+}
+
+/**
+ * @title   EthereumZamaGatewayConfig
+ * @dev     This contract can be inherited by a contract wishing to use the Gateway service
+ *          provided by Zama on the Ethereum (mainnet) network (chainId = 1).
+ *          Other providers may offer other Gateways that are deployed at different addresses.
+ *          If you wish to use them, you should rely on the instructions from these providers.
+ */
+contract EthereumZamaGatewayConfig {
+    constructor() {
+        Gateway.setGateway(ZamaGatewayConfig.getEthereumConfig());
+    }
+}


### PR DESCRIPTION
This PR includes default config files (in Solidity) that can be inherited to automatically set the addresses to use (1) Zama's FHEVM, (2) Zama's Gateway.

In the future, it may be better to create a standardized repo for any service provider to add their config information.

These configs are meant to be imported such as:

```solidity
import {MockZamaFHEVMConfig} from "fhevm/config/ZamaFHEVMConfig.sol";
```

and can be inherited such as:

```solidity
contract MyEncryptedERC20 is MockZamaFHEVMConfig, EncryptedERC20 {
    /// My code
}
