### PR TITLE
docs: fixing a broken link

### DIFF
--- a/docs/references/functions.md
+++ b/docs/references/functions.md
@@ -164,7 +164,7 @@ function max(uint32 a, euint8 b) internal view returns (euint32)
 There are two unary operators: `neg` (`-`) and `not` (`!`). Note that since we work with unsigned integers, the result of negation is interpreted as the modular opposite. The `not` operator returns the value obtained after flipping all the bits of the operand.
 
 {% hint style="info" %}
-More information about the behavior of these operators can be found at the [TFHE-rs docs](https://docs.zama.ai/tfhe-rs/getting_started/operations#arithmetic-operations.).
+More information about the behavior of these operators can be found at the [TFHE-rs docs](https://docs.zama.ai/tfhe-rs/fhe-computation/operations/arithmetic-operations).
 {% endhint %}
 
 ### Bitwise operations


### PR DESCRIPTION
Fixing a broken link to TFHE-rs doc
By the way it means we haven't a check on broken links