### PR TITLE
docs: rename HTTPZ to fhevm

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  HTTPZ is a technology that enables confidential smart contracts on the EVM
+  Fhevm is a technology that enables confidential smart contracts on the EVM
   using Fully Homomorphic Encryption (FHE).
 layout:
   title:
@@ -15,17 +15,17 @@ layout:
     visible: false
 ---
 
-# Welcome to HTTPZ
+# Welcome to fhevm
 
 ## Get started
 
-Learn the basics of HTTPZ, set it up, and make it run with ease.
+Learn the basics of fhevm, set it up, and make it run with ease.
 
-<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Overview</strong></td><td>Explore the suite of HTTPZ protocol.</td><td><a href=".gitbook/assets/start1.png">start1.png</a></td><td><a href="getting-started/overview.md">overview.md</a></td></tr><tr><td><strong>Quick start with Remix</strong></td><td>Learn and prototype in the in-browser IDE.</td><td><a href=".gitbook/assets/start4.png">start4.png</a></td><td><a href="getting-started/overview-1/overview.md">overview.md</a></td></tr><tr><td><strong>Get started with Hardhat</strong></td><td>Develop in production-ready envrionment.</td><td><a href=".gitbook/assets/start5.png">start5.png</a></td><td><a href="./getting-started/overview-1/hardhat/README.md">hardhat.md</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Overview</strong></td><td>Explore the suite of fhevm protocol.</td><td><a href=".gitbook/assets/start1.png">start1.png</a></td><td><a href="getting-started/overview.md">overview.md</a></td></tr><tr><td><strong>Quick start with Remix</strong></td><td>Learn and prototype in the in-browser IDE.</td><td><a href=".gitbook/assets/start4.png">start4.png</a></td><td><a href="getting-started/overview-1/overview.md">overview.md</a></td></tr><tr><td><strong>Get started with Hardhat</strong></td><td>Develop in production-ready envrionment.</td><td><a href=".gitbook/assets/start5.png">start5.png</a></td><td><a href="./getting-started/overview-1/hardhat/README.md">hardhat.md</a></td></tr></tbody></table>
 
-## Develop a HTTPZ smart contract
+## Develop a fhevm smart contract
 
-Start developing HTTPZ smart contracts in Solidity by exploring its core features, discovering essential guides, and learning more with user-friendly tutorials.
+Start developing fhevm smart contracts in Solidity by exploring its core features, discovering essential guides, and learning more with user-friendly tutorials.
 
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><strong>Smart contract</strong></td><td>Learn core Solidity library.</td><td><ul><li><a href="smart_contracts/key_concepts.md">Key features</a></li><li><a href="smart_contracts/types.md">Use encrypted types</a></li></ul></td><td><a href=".gitbook/assets/build1.png">build1.png</a></td></tr><tr><td><strong>Frontend</strong></td><td>Write a dAPP frontend.</td><td><ul><li><a href="frontend/setup.md">Set up</a></li><li><a href="frontend/webapp.md">Build a web application</a></li></ul></td><td><a href=".gitbook/assets/build2.png">build2.png</a></td></tr><tr><td><strong>Tutorials</strong></td><td>Build quickly with tutorials.</td><td><ul><li><a href="tutorials/see-all-tutorials.md">See all tutorials</a></li></ul></td><td><a href=".gitbook/assets/build3.png">build3.png</a></td></tr></tbody></table>
 
@@ -35,16 +35,16 @@ Access to additional resources and join the Zama community.
 
 ### Explanations
 
-Explore the technical architecture of the HTTPZ protocol and the underlying cryptographic principles that power it.
+Explore the technical architecture of the fhevm protocol and the underlying cryptographic principles that power it.
 
 - [Architecture overview](smart_contracts/architecture_overview.md)
 - [FHE on blockchain](smart_contracts/architecture_overview/fhe-on-blockchain.md)
-- [HTTPZ components](smart_contracts/architecture_overview/fhevm-components.md)
+- [Fhevm components](smart_contracts/architecture_overview/fhevm-components.md)
 - [Encryption, decryption re-encryption and computation](smart_contracts/d_re_ecrypt_compute.md)
 
 ### References
 
-Refer to the API and access additional resources for in-depth explanations while working with HTTPZ.
+Refer to the API and access additional resources for in-depth explanations while working with fhevm.
 
 - [API function specifications](references/functions.md)
 - [Repositories](references/repositories.md)
@@ -61,11 +61,11 @@ Ask technical questions and discuss with the community. Our team of experts usua
 
 Collaborate with us to advance the FHE spaces and drive innovation together.
 
-- [Contribute to HTTPZ](developer/contribute.md)
+- [Contribute to fhevm](developer/contribute.md)
 - [Follow the development roadmap](developer/roadmap.md)
-- [See the latest test release note](https://github.com/zama-ai/fhevm/releases)
-- [Request a feature](https://github.com/zama-ai/fhevm/issues/new?assignees=&labels=enhancement&projects=&template=feature-request.md&title=)
-- [Report a bug](https://github.com/zama-ai/fhevm/issues/new?assignees=&labels=bug&projects=&template=bug_report_fhevm.md&title=)
+- [See the latest test release note](https://github.com/zama-ai/fhevm-solidity/releases)
+- [Request a feature](https://github.com/zama-ai/fhevm-solidity/issues/new?assignees=&labels=enhancement&projects=&template=feature-request.md&title=)
+- [Report a bug](https://github.com/zama-ai/fhevm-solidity/issues/new?assignees=&labels=bug&projects=&template=bug_report_fhevm.md&title=)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Fhevm is a technology that enables confidential smart contracts on the EVM
+  fhevm is a technology that enables confidential smart contracts on the EVM
   using Fully Homomorphic Encryption (FHE).
 layout:
   title:
@@ -39,7 +39,7 @@ Explore the technical architecture of the fhevm protocol and the underlying cryp
 
 - [Architecture overview](smart_contracts/architecture_overview.md)
 - [FHE on blockchain](smart_contracts/architecture_overview/fhe-on-blockchain.md)
-- [Fhevm components](smart_contracts/architecture_overview/fhevm-components.md)
+- [fhevm components](smart_contracts/architecture_overview/fhevm-components.md)
 - [Encryption, decryption re-encryption and computation](smart_contracts/d_re_ecrypt_compute.md)
 
 ### References

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,7 +1,7 @@
 # Table of contents
 
-- [Welcome to HTTPZ](README.md)
-- [White paper](https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper-v2.pdf)
+- [Welcome to fhevm](README.md)
+- [White paper](https://github.com/zama-ai/fhevm-solidity/blob/main/fhevm-whitepaper-v2.pdf)
 
 ## Getting Started
 
@@ -28,7 +28,7 @@
 
 - [Key features](smart_contracts/key_concepts.md)
 - [Configuration](smart_contracts/configure.md)
-- [HTTPZ contracts](smart_contracts/contracts.md)
+- [fhevm contracts](smart_contracts/contracts.md)
 - [Supported types](smart_contracts/types.md)
 - [Operations on encrypted types](smart_contracts/operations.md)
 - [Access Control List](smart_contracts/acl/README.md)
@@ -63,21 +63,21 @@
 
 - [Architectural overview](smart_contracts/architecture_overview.md)
 - [FHE on blockchain](smart_contracts/architecture_overview/fhe-on-blockchain.md)
-- [HTTPZ components](smart_contracts/architecture_overview/fhevm-components.md)
+- [fhevm components](smart_contracts/architecture_overview/fhevm-components.md)
 - [Encryption, decryption, re-encryption, and computation](smart_contracts/d_re_ecrypt_compute.md)
 
 ## References
 
 - [Table of all addresses](references/table_of_addresses.md)
-- [Smart contracts - HTTPZ API](references/functions.md)
-- [Frontend - HTTPZ SDK](references/fhevmjs.md)
+- [Smart contracts - fhevm API](references/functions.md)
+- [Frontend - fhevm SDK](references/fhevmjs.md)
 - [Repositories](references/repositories.md)
 
 ## Developer
 
 - [Contributing](developer/contribute.md)
 - [Development roadmap](developer/roadmap.md)
-- [Release note](https://github.com/zama-ai/fhevm/releases)
-- [Feature request](https://github.com/zama-ai/fhevm/issues/new?assignees=&labels=enhancement&projects=&template=feature-request.md&title=)
-- [Bug report](https://github.com/zama-ai/fhevm/issues/new?assignees=&labels=bug&projects=&template=bug_report_fhevm.md&title=)
+- [Release note](https://github.com/zama-ai/fhevm-solidity/releases)
+- [Feature request](https://github.com/zama-ai/fhevm-solidity/issues/new?assignees=&labels=enhancement&projects=&template=feature-request.md&title=)
+- [Bug report](https://github.com/zama-ai/fhevm-solidity/issues/new?assignees=&labels=bug&projects=&template=bug_report_fhevm.md&title=)
 - [Status](https://status.zama.ai/)

--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -1,8 +1,8 @@
 # Contributing
 
-There are two ways to contribute to HTTPZ:
+There are two ways to contribute to fhevm:
 
-- [Open issues](https://github.com/zama-ai/fhevm/issues/new/choose) to report bugs and typos, or to suggest new ideas
+- [Open issues](https://github.com/zama-ai/fhevm-solidity/issues/new/choose) to report bugs and typos, or to suggest new ideas
 - Request to become an official contributor by emailing [hello@zama.ai](mailto:hello@zama.ai).
 
 Becoming an approved contributor involves signing our Contributor License Agreement (CLA). Only approved contributors can send pull requests, so please make sure to get in touch before you do!

--- a/docs/developer/roadmap.md
+++ b/docs/developer/roadmap.md
@@ -1,6 +1,6 @@
 # Development roadmap
 
-This document gives a preview of the upcoming features of HTTPZ. In addition to what's listed here, you can [submit your feature request](https://github.com/zama-ai/fhevm/issues/new?template=feature-request.md) on GitHub.
+This document gives a preview of the upcoming features of fhevm. In addition to what's listed here, you can [submit your feature request](https://github.com/zama-ai/fhevm-solidity/issues/new?template=feature-request.md) on GitHub.
 
 ## Features
 

--- a/docs/frontend/cli.md
+++ b/docs/frontend/cli.md
@@ -1,25 +1,25 @@
 # Using the CLI
 
-The `httpz` Command-Line Interface (CLI) tool provides a simple and efficient way to encrypt data for use with the blockchain's Fully Homomorphic Encryption (FHE) system. This guide explains how to install and use the CLI to encrypt integers and booleans for confidential smart contracts.
+The `fhevm` Command-Line Interface (CLI) tool provides a simple and efficient way to encrypt data for use with the blockchain's Fully Homomorphic Encryption (FHE) system. This guide explains how to install and use the CLI to encrypt integers and booleans for confidential smart contracts.
 
 ## Installation
 
-Ensure you have [Node.js](https://nodejs.org/) installed on your system before proceeding. Then, globally install the `@httpz/sdk` package to enable the CLI tool:
+Ensure you have [Node.js](https://nodejs.org/) installed on your system before proceeding. Then, globally install the `@fhevm/sdk` package to enable the CLI tool:
 
 ```bash
-npm install -g @httpz/sdk
+npm install -g @fhevm/sdk
 ```
 
-Once installed, you can access the CLI using the `httpz` command. Verify the installation and explore available commands using:
+Once installed, you can access the CLI using the `fhevm` command. Verify the installation and explore available commands using:
 
 ```bash
-httpz help
+fhevm help
 ```
 
 To see specific options for encryption, run:
 
 ```bash
-httpz encrypt help
+fhevm encrypt help
 ```
 
 ## Encrypting Data
@@ -29,7 +29,7 @@ The CLI allows you to encrypt integers and booleans for use in smart contracts. 
 ### Syntax
 
 ```bash
-httpz encrypt --node <NODE_URL> <CONTRACT_ADDRESS> <USER_ADDRESS> <DATA:TYPE>...
+fhevm encrypt --node <NODE_URL> <CONTRACT_ADDRESS> <USER_ADDRESS> <DATA:TYPE>...
 ```
 
 - **`--node`**: Specifies the RPC URL of the blockchain node (e.g., `http://localhost:8545`).
@@ -44,5 +44,5 @@ httpz encrypt --node <NODE_URL> <CONTRACT_ADDRESS> <USER_ADDRESS> <DATA:TYPE>...
 Encrypt the integer `71721075` (64-bit) and the boolean `1` for the contract at `0x8Fdb26641d14a80FCCBE87BF455338Dd9C539a50` and the user at `0xa5e1defb98EFe38EBb2D958CEe052410247F4c80`:
 
 ```bash
-httpz encrypt --node http://localhost:8545 0x8Fdb26641d14a80FCCBE87BF455338Dd9C539a50 0xa5e1defb98EFe38EBb2D958CEe052410247F4c80 71721075:64 1:1
+fhevm encrypt --node http://localhost:8545 0x8Fdb26641d14a80FCCBE87BF455338Dd9C539a50 0xa5e1defb98EFe38EBb2D958CEe052410247F4c80 71721075:64 1:1
 ```

--- a/docs/frontend/node.md
+++ b/docs/frontend/node.md
@@ -1,6 +1,6 @@
 # Build with Node
 
-This document provides instructions on how to build with `Node.js` using the `@httpz/sdk` library.
+This document provides instructions on how to build with `Node.js` using the `@fhevm/sdk` library.
 
 ## Install the library
 
@@ -8,16 +8,16 @@ First, you need to install the library:
 
 ```bash
 # Using npm
-npm install @httpz/sdk
+npm install @fhevm/sdk
 
 # Using Yarn
-yarn add @httpz/sdk
+yarn add @fhevm/sdk
 
 # Using pnpm
-pnpm add @httpz/sdk
+pnpm add @fhevm/sdk
 ```
 
-`@httpz/sdk` uses ESM format for web version and commonjs for node version. You need to set the [type to "commonjs" in your package.json](https://nodejs.org/api/packages.html#type) to load the correct version of @httpz/sdk. If your node project use `"type": "module"`, you can force the loading of the Node version by using `import { createInstance } from '@httpz/sdk/node';`
+`@fhevm/sdk` uses ESM format for web version and commonjs for node version. You need to set the [type to "commonjs" in your package.json](https://nodejs.org/api/packages.html#type) to load the correct version of @fhevm/sdk. If your node project use `"type": "module"`, you can force the loading of the Node version by using `import { createInstance } from '@fhevm/sdk/node';`
 
 ## Create an instance
 
@@ -31,7 +31,7 @@ An instance receives an object containing:
 - `coprocessorUrl` (optional): the URL of the coprocessor
 
 ```javascript
-const { createInstance } = require("@httpz/sdk");
+const { createInstance } = require("@fhevm/sdk");
 
 const createFhevmInstance = async () => {
   return createInstance({

--- a/docs/frontend/webapp.md
+++ b/docs/frontend/webapp.md
@@ -39,7 +39,7 @@ Include this line at the top of your project.
 In your project, you can use the bundle import if you install `@fhevm/sdk` package:
 
 ```javascript
-import { initfhevm, createInstance } from "@fhevm/sdk/bundle";
+import { initFhevm, createInstance } from "@fhevm/sdk/bundle";
 ```
 
 #### Using ESM CDN
@@ -48,9 +48,9 @@ If you prefer You can also use the `@fhevm/sdk` as a ES module:
 
 ```html
 <script type="module">
-  import { initfhevm, createInstance } from "https://cdn.zama.ai/fhevmjs/0.6.2/fhevmjs.js";
+  import { initFhevm, createInstance } from "https://cdn.zama.ai/fhevmjs/0.6.2/fhevmjs.js";
 
-  await initfhevm();
+  await initFhevm();
   const instance = await createInstance({
     network: window.ethereum,
     kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",
@@ -78,18 +78,18 @@ pnpm add @fhevm/sdk
 `@fhevm/sdk` uses ESM format. You need to set the [type to "module" in your package.json](https://nodejs.org/api/packages.html#type). If your node project use `"type": "commonjs"` or no type, you can force the loading of the web version by using `import { createInstance } from '@fhevm/sdk/web';`
 
 ```javascript
-import { initfhevm, createInstance } from "@fhevm/sdk";
+import { initFhevm, createInstance } from "@fhevm/sdk";
 ```
 
 ### Step 2: Initialize your project
 
-To use the library in your project, you need to load the WASM of [TFHE](https://www.npmjs.com/package/tfhe) first with `initfhevm`.
+To use the library in your project, you need to load the WASM of [TFHE](https://www.npmjs.com/package/tfhe) first with `initFhevm`.
 
 ```javascript
-import { initfhevm } from "@fhevm/sdk/bundle";
+import { initFhevm } from "@fhevm/sdk/bundle";
 
 const init = async () => {
-  await initfhevm(); // Load needed WASM
+  await initFhevm(); // Load needed WASM
 };
 ```
 
@@ -105,10 +105,10 @@ Once the WASM is loaded, you can now create an instance. An instance receives an
 - `coprocessorUrl` (optional): the URL of the coprocessor
 
 ```javascript
-import { initfhevm, createInstance } from "@fhevm/sdk/bundle";
+import { initFhevm, createInstance } from "@fhevm/sdk/bundle";
 
 const init = async () => {
-  await initfhevm(); // Load TFHE
+  await initFhevm(); // Load TFHE
   return createInstance({
     kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",
     aclContractAddress: "0xFee8407e2f5e3Ee68ad77cAE98c434e637f516e5",

--- a/docs/frontend/webapp.md
+++ b/docs/frontend/webapp.md
@@ -1,32 +1,32 @@
 # Build a web application
 
-This document guides you through building a web application using the @httpz/sdk library. You can either start with a template or directly integrate the library into your project.
+This document guides you through building a web application using the @fhevm/sdk library. You can either start with a template or directly integrate the library into your project.
 
 ## Using a template
 
-`@httpz/sdk` is working out of the box and we recommend you to use it. We also provide three GitHub templates to start your project with everything set.
+`@fhevm/sdk` is working out of the box and we recommend you to use it. We also provide three GitHub templates to start your project with everything set.
 
 ### React + TypeScript
 
-You can use [this template](https://github.com/zama-ai/fhevmjs-react-template) to start an application with @httpz/sdk, using Vite + React + TypeScript.
+You can use [this template](https://github.com/zama-ai/fhevmjs-react-template) to start an application with @fhevm/sdk, using Vite + React + TypeScript.
 
 ### VueJS + TypeScript
 
-You can also use [this template](https://github.com/zama-ai/fhevmjs-vue-template) to start an application with @httpz/sdk, using Vite + Vue + TypeScript.
+You can also use [this template](https://github.com/zama-ai/fhevmjs-vue-template) to start an application with @fhevm/sdk, using Vite + Vue + TypeScript.
 
 ### NextJS + Typescript
 
-You can also use [this template](https://github.com/zama-ai/fhevmjs-next-template) to start an application with @httpz/sdk, using Next + TypeScript.
+You can also use [this template](https://github.com/zama-ai/fhevmjs-next-template) to start an application with @fhevm/sdk, using Next + TypeScript.
 
 ## Using the mocked coprocessor for frontend
 
-As an alternative to use the real coprocessor deployed on Sepolia to help you develop your dApp faster and without needing testnet tokens, you can use a mocked HTTPZ. Currently, we recommend you to use the `ConfidentialERC20` dApp example available on the `mockedFrontend` branch of the [React template](https://github.com/zama-ai/fhevm-react-template/tree/mockedFrontend). Follow the README on this branch, and you will be able to deploy exactly the same dApp both on Sepolia as well as on the mocked coprocessor seamlessly.
+As an alternative to use the real coprocessor deployed on Sepolia to help you develop your dApp faster and without needing testnet tokens, you can use a mocked fhevm. Currently, we recommend you to use the `ConfidentialERC20` dApp example available on the `mockedFrontend` branch of the [React template](https://github.com/zama-ai/fhevm-react-template/tree/mockedFrontend). Follow the README on this branch, and you will be able to deploy exactly the same dApp both on Sepolia as well as on the mocked coprocessor seamlessly.
 
 ## Using directly the library
 
 ### Step 1: Setup the library
 
-`@httpz/sdk` consists of multiple files, including WASM files and WebWorkers, which can make packaging these components correctly in your setup cumbersome. To simplify this process, especially if you're developing a dApp with server-side rendering (SSR), we recommend using our CDN.
+`@fhevm/sdk` consists of multiple files, including WASM files and WebWorkers, which can make packaging these components correctly in your setup cumbersome. To simplify this process, especially if you're developing a dApp with server-side rendering (SSR), we recommend using our CDN.
 
 #### Using UMD CDN
 
@@ -36,21 +36,21 @@ Include this line at the top of your project.
 <script src="https://cdn.zama.ai/fhevmjs/0.6.2/fhevmjs.umd.cjs" type="text/javascript"></script>
 ```
 
-In your project, you can use the bundle import if you install `@httpz/sdk` package:
+In your project, you can use the bundle import if you install `@fhevm/sdk` package:
 
 ```javascript
-import { initHTTPZ, createInstance } from "@httpz/sdk/bundle";
+import { initfhevm, createInstance } from "@fhevm/sdk/bundle";
 ```
 
 #### Using ESM CDN
 
-If you prefer You can also use the `@httpz/sdk` as a ES module:
+If you prefer You can also use the `@fhevm/sdk` as a ES module:
 
 ```html
 <script type="module">
-  import { initHTTPZ, createInstance } from "https://cdn.zama.ai/fhevmjs/0.6.2/fhevmjs.js";
+  import { initfhevm, createInstance } from "https://cdn.zama.ai/fhevmjs/0.6.2/fhevmjs.js";
 
-  await initHTTPZ();
+  await initfhevm();
   const instance = await createInstance({
     network: window.ethereum,
     kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",
@@ -62,34 +62,34 @@ If you prefer You can also use the `@httpz/sdk` as a ES module:
 
 #### Using npm package
 
-Install the `@httpz/sdk` library to your project:
+Install the `@fhevm/sdk` library to your project:
 
 ```bash
 # Using npm
-npm install @httpz/sdk
+npm install @fhevm/sdk
 
 # Using Yarn
-yarn add @httpz/sdk
+yarn add @fhevm/sdk
 
 # Using pnpm
-pnpm add @httpz/sdk
+pnpm add @fhevm/sdk
 ```
 
-`@httpz/sdk` uses ESM format. You need to set the [type to "module" in your package.json](https://nodejs.org/api/packages.html#type). If your node project use `"type": "commonjs"` or no type, you can force the loading of the web version by using `import { createInstance } from '@httpz/sdk/web';`
+`@fhevm/sdk` uses ESM format. You need to set the [type to "module" in your package.json](https://nodejs.org/api/packages.html#type). If your node project use `"type": "commonjs"` or no type, you can force the loading of the web version by using `import { createInstance } from '@fhevm/sdk/web';`
 
 ```javascript
-import { initHTTPZ, createInstance } from "@httpz/sdk";
+import { initfhevm, createInstance } from "@fhevm/sdk";
 ```
 
 ### Step 2: Initialize your project
 
-To use the library in your project, you need to load the WASM of [TFHE](https://www.npmjs.com/package/tfhe) first with `initHTTPZ`.
+To use the library in your project, you need to load the WASM of [TFHE](https://www.npmjs.com/package/tfhe) first with `initfhevm`.
 
 ```javascript
-import { initHTTPZ } from "@httpz/sdk/bundle";
+import { initfhevm } from "@fhevm/sdk/bundle";
 
 const init = async () => {
-  await initHTTPZ(); // Load needed WASM
+  await initfhevm(); // Load needed WASM
 };
 ```
 
@@ -105,10 +105,10 @@ Once the WASM is loaded, you can now create an instance. An instance receives an
 - `coprocessorUrl` (optional): the URL of the coprocessor
 
 ```javascript
-import { initHTTPZ, createInstance } from "@httpz/sdk/bundle";
+import { initfhevm, createInstance } from "@fhevm/sdk/bundle";
 
 const init = async () => {
-  await initHTTPZ(); // Load TFHE
+  await initfhevm(); // Load TFHE
   return createInstance({
     kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",
     aclContractAddress: "0xFee8407e2f5e3Ee68ad77cAE98c434e637f516e5",

--- a/docs/frontend/webpack.md
+++ b/docs/frontend/webpack.md
@@ -58,7 +58,7 @@ resolve: {
 
 ```javascript
 const start = async () => {
-  await window.fhevm.initfhevm(); // load wasm needed
+  await window.fhevm.initFhevm(); // load wasm needed
   const instance = window.fhevm
     .createInstance({
       kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",

--- a/docs/frontend/webpack.md
+++ b/docs/frontend/webpack.md
@@ -54,12 +54,12 @@ resolve: {
 
 **Cause:** The library may not bundle correctly with certain frameworks, leading to errors during the build or runtime process.
 
-**Possible solutions:** Use the [prebundled version available](./webapp.md) with `@httpz/sdk/bundle`. Embed the library with a `<script>` tag and initialize it as shown below:
+**Possible solutions:** Use the [prebundled version available](./webapp.md) with `@fhevm/sdk/bundle`. Embed the library with a `<script>` tag and initialize it as shown below:
 
 ```javascript
 const start = async () => {
-  await window.httpz.initHTTPZ(); // load wasm needed
-  const instance = window.httpz
+  await window.fhevm.initfhevm(); // load wasm needed
+  const instance = window.fhevm
     .createInstance({
       kmsContractAddress: "0x9D6891A6240D6130c54ae243d8005063D05fE14b",
       aclContractAddress: "0xFee8407e2f5e3Ee68ad77cAE98c434e637f516e5",

--- a/docs/getting-started/overview-1/hardhat/1.-setting-up-hardhat.md
+++ b/docs/getting-started/overview-1/hardhat/1.-setting-up-hardhat.md
@@ -1,10 +1,10 @@
 # 1. Setting up Hardhat
 
-This guide walks you through setting up your Hardhat environment using HTTPZ Hardhat template.
+This guide walks you through setting up your Hardhat environment using fhevm Hardhat template.
 
 ## Step 1: Clone the Hardhat template
 
-1. Open the repository: [HTTPZ Hardhat Template](https://github.com/zama-ai/fhevm-hardhat-template)
+1. Open the repository: [fhevm Hardhat Template](https://github.com/zama-ai/fhevm-hardhat-template)
 2. Click "Use this template" to create a new repository under your GitHub account.
 3. Clone the repository you have created to your local environment
 4. Copy the repository URL of your newly created repository.
@@ -52,4 +52,4 @@ To learn more about Hardhat, refer to the [official Hardhat documentation](https
 
 ---
 
-You are now ready to start building your confidential smart contracts with HTTPZ!
+You are now ready to start building your confidential smart contracts with fhevm!

--- a/docs/getting-started/overview-1/hardhat/2.-writing-contracts.md
+++ b/docs/getting-started/overview-1/hardhat/2.-writing-contracts.md
@@ -1,6 +1,6 @@
 # 2. Writing contracts
 
-This document explains how to write confidential smart contract using HTTPZ in Hardhat projects.
+This document explains how to write confidential smart contract using fhevm in Hardhat projects.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ import "fhevm/config/ZamaFHEVMConfig.sol";
 import "fhevm-contracts/contracts/token/ERC20/extensions/ConfidentialERC20Mintable.sol";
 ```
 
-- **`TFHE.sol`**: The core Solidity library of HTTPZ. It enables encrypted data type like `euint64`, secures encrypted operations, such as addition and comparison and allows access control.
+- **`TFHE.sol`**: The core Solidity library of fhevm. It enables encrypted data type like `euint64`, secures encrypted operations, such as addition and comparison and allows access control.
 - **`SepoliaZamaFHEVMConfig`**: A configuration contract that automatically sets up the required configurations for real-time encrypted operations on the Sepolia testnet.
 - **`ConfidentialERC20Mintable.sol`** : The confidential smart contract that allows for full ERC20 compatibility with FHE encryption.
 
@@ -51,18 +51,18 @@ contract MyConfidentialERC20 is SepoliaZamaFHEVMConfig, ConfidentialERC20Mintabl
 
 This is a simple basic contract that we will deploy and use in this tutorial. To write more complex confidential smart contracts or customize your own functions:
 
-- Explore the full range of HTTPZ capabilities in the [**Smart Contract**](../../../smart_contracts/key_concepts.md) section.
+- Explore the full range of fhevm capabilities in the [**Smart Contract**](../../../smart_contracts/key_concepts.md) section.
 - Use the **`fhevm-contracts`** library and extend from the basic contract templates.
 
 {% hint style="info" %}
-The **fhevm-contracts** is a Solidity library designed for developers to easily develop confidential smart contracts using HTTPZ. It provides:
+The **fhevm-contracts** is a Solidity library designed for developers to easily develop confidential smart contracts using fhevm. It provides:
 
 - **Ready-to-use confidential contracts**: Pre-built implementations of common token standards with FHE capabilities
 - **Base contracts**: Foundational building blocks for creating custom confidential smart contracts
 - **Extensions**: Additional features and utilities that can be added to base contracts
 - **Testing utilities**: Tools to help test FHE-enabled smart contracts
 
-See more details in [the HTTPZ-contracts documentation](../../../smart_contracts/contracts.md).
+See more details in [the fhevm-contracts documentation](../../../smart_contracts/contracts.md).
 {% endhint %}
 
 ---

--- a/docs/getting-started/overview-1/hardhat/3.-testing-in-mocked-mode.md
+++ b/docs/getting-started/overview-1/hardhat/3.-testing-in-mocked-mode.md
@@ -1,23 +1,23 @@
 # 3. Testing in mocked mode
 
-This tutorial walks you through performing tests in the **mocked** mode provided by the HTTPZ Hardhat template.
+This tutorial walks you through performing tests in the **mocked** mode provided by the fhevm Hardhat template.
 
 ## Prerequisites
 
 Before proceeding, ensure you have:
 
-- A configured Hardhat project using the HTTPZ Hardhat template. (See the [previous section](1.-setting-up-hardhat.md))
+- A configured Hardhat project using the fhevm Hardhat template. (See the [previous section](1.-setting-up-hardhat.md))
 - Basic knowledge of Solidity and Hardhat testing. (See the [Hardhat testing documentation](https://hardhat.org/hardhat-runner/docs/guides/test-contracts))
 
 {% hint style="info" %}
-HTTPZ provides a **mocked mode** in Hardhat that allows for:
+fhevm provides a **mocked mode** in Hardhat that allows for:
 
 - Faster testing on a local Hardhat network.
 - The ability to analyze code coverage.
 - A simulated version of encrypted types (they are not truly encrypted).
 - Access to Hardhat features such as snapshots (`evm_snapshot`), time manipulation (`evm_increaseTime`), and debugging (`console.log`).
 
-To learn more about the HTTPZ **mocked** mode, refer to the README in the [HTTPZ Hardhat template repository](https://github.com/zama-ai/fhevm-hardhat-template).
+To learn more about the fhevm **mocked** mode, refer to the README in the [fhevm Hardhat template repository](https://github.com/zama-ai/fhevm-hardhat-template).
 {% endhint %}
 
 ## Running your tests

--- a/docs/getting-started/overview-1/hardhat/4.-deploying-the-contract.md
+++ b/docs/getting-started/overview-1/hardhat/4.-deploying-the-contract.md
@@ -6,7 +6,7 @@ This guide walks you through deploying your Confidential ERC20 smart contract on
 
 Before proceeding, ensure you have:
 
-- A configured Hardhat project using the HTTPZ Hardhat Template (see previous sections).
+- A configured Hardhat project using the fhevm Hardhat Template (see previous sections).
 - A crypto wallet installed (e.g., Metamask).
 - Some Sepolia ETH available for testing. If you don’t have enough ETH, use a Sepolia faucet to request free SepoliaETH for testing:
   - [Alchemy Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)

--- a/docs/getting-started/overview-1/hardhat/5.-interacting-with-the-contract.md
+++ b/docs/getting-started/overview-1/hardhat/5.-interacting-with-the-contract.md
@@ -1,6 +1,6 @@
 # 5. Interacting with the contract
 
-After deploying your first **HTTPZ** contract using **Hardhat**, this guide shows you how to interact with it using Hardhat tasks.
+After deploying your first **fhevm** contract using **Hardhat**, this guide shows you how to interact with it using Hardhat tasks.
 
 ## Prerequisites
 
@@ -139,15 +139,15 @@ npx hardhat help <task-name>
 
 ## Next steps
 
-🎉 **Congratulations on completing this tutorial!** You’ve taken the first step in building confidential smart contracts using **HTTPZ**. It's time now to take the next step and build your own confidential dApps!
+🎉 **Congratulations on completing this tutorial!** You’ve taken the first step in building confidential smart contracts using **fhevm**. It's time now to take the next step and build your own confidential dApps!
 
 ### 1. Resources
 
 To continue your journey and deepen your knowledge, explore the resources below.
 
-- [**Read the white paper**](https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper-v2.pdf): Understand the core technology behind fhEVM, including its cryptographic foundations and use cases.
+- [**Read the white paper**](https://github.com/zama-ai/fhevm-solidity/blob/main/fhevm-whitepaper-v2.pdf): Understand the core technology behind fhevm, including its cryptographic foundations and use cases.
 - [**See more demos and tutorials**](../../../tutorials/see-all-tutorials.md): Expand your skills with hands-on demos and tutorials crafted to guide you through various real-world scenarios.
-- [**Try out AI coding assistant**](https://chatgpt.com/g/g-67518aee3c708191b9f08d077a7d6fa1-zama-solidity-developer): If you have a ChatGPT plus account, try out our custom ChatGPT model tailored for Solidity and HTTPZ developers.
+- [**Try out AI coding assistant**](https://chatgpt.com/g/g-67518aee3c708191b9f08d077a7d6fa1-zama-solidity-developer): If you have a ChatGPT plus account, try out our custom ChatGPT model tailored for Solidity and fhevm developers.
 
 ### 2. Tools
 
@@ -155,8 +155,8 @@ Use out-of-box templates and frameworks designed for developers to build confide
 
 **Smart contract development**
 
-- [**Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template): A developer-friendly starting point for building and testing smart contracts on HTTPZ.
-- [**HTTPZ Contracts Library**](https://github.com/zama-ai/fhevm-contracts): Access standardized contracts for encrypted operations.
+- [**Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template): A developer-friendly starting point for building and testing smart contracts on fhevm.
+- [**fhevm Contracts Library**](https://github.com/zama-ai/fhevm-contracts): Access standardized contracts for encrypted operations.
 
 **Frontend development**
 
@@ -169,5 +169,5 @@ Use out-of-box templates and frameworks designed for developers to build confide
 Join the community to shape the future of blockchain together with us.
 
 - [**Discord**](https://discord.gg/zama-ai): Join the community to get the latest update, have live discussion with fellow developers and Zama team.
-- [**Community Forum**](https://community.zama.ai/): Get support on all technical questions related to HTTPZ
+- [**Community Forum**](https://community.zama.ai/): Get support on all technical questions related to fhevm
 - [**Zama Bounty Program**](https://github.com/zama-ai/bounty-program): Participate to tackle challenges and earn rewards in cash.

--- a/docs/getting-started/overview-1/hardhat/README.md
+++ b/docs/getting-started/overview-1/hardhat/README.md
@@ -1,12 +1,12 @@
 # Hardhat
 
-This tutorial covers the essential steps to quickly write and deploy a confidential ERC20 smart contract using the [HTTPZ Hardhat template](https://github.com/zama-ai/fhevm-hardhat-template).
+This tutorial covers the essential steps to quickly write and deploy a confidential ERC20 smart contract using the [fhevm Hardhat template](https://github.com/zama-ai/fhevm-hardhat-template).
 
-Hardhat is a flexible, extensible development environment for Ethereum, providing a robust toolkit for compiling, testing, and deploying smart contracts. With Zama’s HTTPZ integration, you can develop confidential ERC20 contracts locally and then seamlessly deploy them to a real HTTPZ node.
+Hardhat is a flexible, extensible development environment for Ethereum, providing a robust toolkit for compiling, testing, and deploying smart contracts. With Zama’s fhevm integration, you can develop confidential ERC20 contracts locally and then seamlessly deploy them to a real fhevm node.
 
 **In this tutorial, you will learn to:**
 
-1. Set up a Hardhat project with the [**HTTPZ Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template).
+1. Set up a Hardhat project with the [**fhevm Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template).
 2. Write confidential contracts utilizing encrypted data types.
 3. Test your contracts in **mocked mode** (for rapid feedback and coverage).
 4. Deploy your confidential ERC20 contract to the Sepolia test network.

--- a/docs/getting-started/overview-1/hardhat/prerequisites.md
+++ b/docs/getting-started/overview-1/hardhat/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-This guide will walk you through installing all necessary dependencies from scratch, preparing you for developing and deploying HTTPZ smart contracts using Hardhat.
+This guide will walk you through installing all necessary dependencies from scratch, preparing you for developing and deploying fhevm smart contracts using Hardhat.
 
 To use Hardhat to build and deploy confidential smart contract, you need to have the following:
 

--- a/docs/getting-started/overview-1/remix/README.md
+++ b/docs/getting-started/overview-1/remix/README.md
@@ -2,11 +2,11 @@
 
 This tutorial covers the essentials steps to quickly write and deploy confidential ERC20 smart contract using the Zama Plug in.
 
-Remix is a powerful in-browser IDE for Ethereum smart contract development. It offers a fast, intuitive way to write and deploy confidential ERC20 contracts using Zama’s HTTPZ plugin—no local setup required.
+Remix is a powerful in-browser IDE for Ethereum smart contract development. It offers a fast, intuitive way to write and deploy confidential ERC20 contracts using Zama’s fhevm plugin—no local setup required.
 
 **In this tutorial, you will learn to:**
 
-1. Set up Remix for HTTPZ development.
+1. Set up Remix for fhevm development.
 2. Connect your wallet (e.g., MetaMask) to Remix.
 3. Deploy a **ConfidentialERC20** contract.
 4. Interact with your deployed contract directly in the Remix interface.

--- a/docs/getting-started/overview-1/remix/connect_wallet.md
+++ b/docs/getting-started/overview-1/remix/connect_wallet.md
@@ -1,6 +1,6 @@
 # 2. Connect your wallet to Remix
 
-In this guide, you'll learn how to connect your wallet and the **Zama Plugin** in Remix IDE to interact with HTTPZ smart contracts.
+In this guide, you'll learn how to connect your wallet and the **Zama Plugin** in Remix IDE to interact with fhevm smart contracts.
 
 ## Prerequisites
 
@@ -49,7 +49,7 @@ If Sepolia isn’t pre-configured in your wallet, add it manually:
 
 ## Step 2. Connecting to Zama Plugin
 
-**Zama Plugin** provides the **Zama Coprocessor - Sepolia configuration** that ensures Remix and the wallet are properly set up to interact with HTTPZ smart contracts.
+**Zama Plugin** provides the **Zama Coprocessor - Sepolia configuration** that ensures Remix and the wallet are properly set up to interact with fhevm smart contracts.
 
 To complete the configuration:
 

--- a/docs/getting-started/overview-1/remix/deploying_cerc20.md
+++ b/docs/getting-started/overview-1/remix/deploying_cerc20.md
@@ -1,6 +1,6 @@
 # 3. Deploying ConfidentialERC20
 
-In this tutorial, you'll learn how to deploy a confidential token contract using **HTTPZ**. We'll create `MyConfidentialERC20.sol` to demonstrate the essential features.
+In this tutorial, you'll learn how to deploy a confidential token contract using **fhevm**. We'll create `MyConfidentialERC20.sol` to demonstrate the essential features.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ First, let's create a file for our confidential ERC20 contract:
 
 ### Step 2.1 Basic contract structure
 
-The foundational structure includes importing Zama's libraries and connecting to Sepolia's HTTPZ configuration.
+The foundational structure includes importing Zama's libraries and connecting to Sepolia's fhevm configuration.
 
 Copy the following code in the `MyConfidentialERC20.sol` that you just created:
 
@@ -45,7 +45,7 @@ It should appear as follows:
 
 Remix automatically saves any changes as you type. Upon saving, it imports the following libraries:
 
-- **`TFHE.sol`**: The core Solidity library of HTTPZ. It enables encrypted data type like `euint64`, secures encrypted operations, such as addition and comparison and allows access control.
+- **`TFHE.sol`**: The core Solidity library of fhevm. It enables encrypted data type like `euint64`, secures encrypted operations, such as addition and comparison and allows access control.
 - **`SepoliaZamaFHEVMConfig`**: A configuration contract that automatically sets up the required configurations for real-time encrypted operations on the Sepolia testnet.
 
 ### Step 2.2 Enhancing the functionality
@@ -53,14 +53,14 @@ Remix automatically saves any changes as you type. Upon saving, it imports the f
 Next, we'll enhance our contract by importing the `fhevm-contracts` library.
 
 {% hint style="info" %}
-The **fhevm-contracts** is a Solidity library designed for developers to easily develop confidential smart contracts using HTTPZ. It provides:
+The **fhevm-contracts** is a Solidity library designed for developers to easily develop confidential smart contracts using fhevm. It provides:
 
 - **Ready-to-use confidential contracts**: Pre-built implementations of common token standards with FHE capabilities
 - **Base contracts**: Foundational building blocks for creating custom confidential smart contracts
 - **Extensions**: Additional features and utilities that can be added to base contracts
 - **Testing utilities**: Tools to help test FHE-enabled smart contracts
 
-See more details in [the fhEVM-contracts documentation](../../../smart_contracts/contracts.md).
+See more details in [the fhevm-contracts documentation](../../../smart_contracts/contracts.md).
 {% endhint %}
 
 The `fhevm-contracts` library includes the `ConfidentialERC20Mintable` contract, which is an extention of `ConfidentialERC20` with minting capabilities, providing:
@@ -121,4 +121,4 @@ Once successfully deployed, your contract will appear under **Deployed Contracts
 
 ---
 
-By following these steps, you’ve successfully created and deployed an confidential ERC-20 token using HTTPZ!🎉 Let's see how the transaction works in the next chapter.
+By following these steps, you’ve successfully created and deployed an confidential ERC-20 token using fhevm!🎉 Let's see how the transaction works in the next chapter.

--- a/docs/getting-started/overview-1/remix/interact.md
+++ b/docs/getting-started/overview-1/remix/interact.md
@@ -1,6 +1,6 @@
 # 4. Interacting with the contract
 
-After deploying your first **HTTPZ** contract using **Remix**, this guide shows you how to interact with it directly in Remix using the **Zama Plugin**.
+After deploying your first **fhevm** contract using **Remix**, this guide shows you how to interact with it directly in Remix using the **Zama Plugin**.
 
 ## Prerequisite
 
@@ -104,15 +104,15 @@ Always re-encrypt to validate ciphertext transformations and confirm operations.
 
 ## Next steps
 
-🎉 **Congratulations on completing this tutorial!** You’ve taken the first step in building confidential smart contracts using **HTTPZ**. It's time now to take the next step and build your own confidential dApps!
+🎉 **Congratulations on completing this tutorial!** You’ve taken the first step in building confidential smart contracts using **fhevm**. It's time now to take the next step and build your own confidential dApps!
 
 ### 1. Resources
 
 To continue your journey and deepen your knowledge, explore the resources below.
 
-- [**Read the Whitepaper**](https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper-v2.pdf): Understand the core technology behind HTTPZ, including its cryptographic foundations and use cases.
+- [**Read the Whitepaper**](https://github.com/zama-ai/fhevm-solidity/blob/main/fhevm-whitepaper-v2.pdf): Understand the core technology behind fhevm, including its cryptographic foundations and use cases.
 - [**See more demos and tutorials**](../../../tutorials/see-all-tutorials.md): Expand your skills with hands-on demos and tutorials crafted to guide you through various real-world scenarios.
-- [**Try out AI coding assistant**](https://chatgpt.com/g/g-67518aee3c708191b9f08d077a7d6fa1-zama-solidity-developer): If you have a chatGPT plus account, try out our custom ChatGPT model tailored for Solidity and HTTPZ developers.
+- [**Try out AI coding assistant**](https://chatgpt.com/g/g-67518aee3c708191b9f08d077a7d6fa1-zama-solidity-developer): If you have a chatGPT plus account, try out our custom ChatGPT model tailored for Solidity and fhevm developers.
 
 ### 2. Tools
 
@@ -120,8 +120,8 @@ Use out-of-box templates and frameworks designed for developers to build confide
 
 **Smart contract development**
 
-- [**Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template): A developer-friendly starting point for building and testing smart contracts on HTTPZ.
-- [**HTTPZ Contracts Library**](https://github.com/zama-ai/fhevm-contracts): Access standardized contracts for encrypted operations.
+- [**Hardhat Template**](https://github.com/zama-ai/fhevm-hardhat-template): A developer-friendly starting point for building and testing smart contracts on fhevm.
+- [**fhevm Contracts Library**](https://github.com/zama-ai/fhevm-contracts): Access standardized contracts for encrypted operations.
 
 **Frontend development**
 
@@ -134,5 +134,5 @@ Use out-of-box templates and frameworks designed for developers to build confide
 Join the community to shape the future of blockchain together with us.
 
 - [**Discord**](https://discord.gg/zama-ai): Join the community to get the latest update, have live discussion with fellow developers and Zama team.
-- [**Community Forum**](https://community.zama.ai/): Get support on all technical questions related to HTTPZ
+- [**Community Forum**](https://community.zama.ai/): Get support on all technical questions related to fhevm
 - [**Zama Bounty Program**](https://github.com/zama-ai/bounty-program): Participate to tackle challenges and earn rewards in cash.

--- a/docs/getting-started/overview-1/remix/remix.md
+++ b/docs/getting-started/overview-1/remix/remix.md
@@ -1,6 +1,6 @@
 # 1. Setting up Remix
 
-This guide helps you set up the **Zama Plugin** in the official Remix IDE, enabling seamless development and management of smart contracts using the **HTTPZ**.
+This guide helps you set up the **Zama Plugin** in the official Remix IDE, enabling seamless development and management of smart contracts using the **fhevm**.
 
 ## Prerequisites
 
@@ -34,4 +34,4 @@ Use the following configurations:
 
 ---
 
-Now that you've configured the plugin, you are able to deploy and interact with **HTTPZ** encrypted contracts directly directly via Remix interface. Next, let's dive into the contract deployment.
+Now that you've configured the plugin, you are able to deploy and interact with **fhevm** encrypted contracts directly directly via Remix interface. Next, let's dive into the contract deployment.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -2,19 +2,19 @@
 
 <figure><img src="../.gitbook/assets/doc_header_fhevm.png" alt=""><figcaption></figcaption></figure>
 
-HTTPZ is a suite of solutions that enables confidential smart contracts on the EVM using **Fully Homomorphic Encryption (FHE)**. This document provides a high-level overview of the HTTPZ suite along with onboarding guidance tailored to specific audiences.
+fhevm is a suite of solutions that enables confidential smart contracts on the EVM using **Fully Homomorphic Encryption (FHE)**. This document provides a high-level overview of the fhevm suite along with onboarding guidance tailored to specific audiences.
 
 ### For dApp developers
 
-The HTTPZ Protocol provides a **`TFHE` Solidity library** for building confidential smart contracts, a **HTTPZ SDK** to enable front‐end FHE interactions, and a range of developer tools, examples, and templates to streamline the usage for developers.&#x20;
+The fhevm Protocol provides a **`TFHE` Solidity library** for building confidential smart contracts, a **fhevm SDK** to enable front‐end FHE interactions, and a range of developer tools, examples, and templates to streamline the usage for developers.&#x20;
 
 #### Smart contract development
 
-<table><thead><tr><th width="245">Repository</th><th width="580">Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevm/">HTTPZ</a></td><td>Solidity library for FHE operations (e.g., encryption/decryption, arithmetic) within smart contracts.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-hardhat-template">fhevm-hardhat-template</a></td><td>Hardhat template with scripts for compiling, deploying, and testing FHE‐enabled contracts.</td></tr><tr><td>fhevm-foundry-template - <em>coming soon</em></td><td>Foundry template for building FHE smart contracts.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-contracts">fhevm-contracts</a></td><td>Ready‐to‐use FHE smart contract example covering finance, governance, and ERC‐20 tokens use cases.</td></tr></tbody></table>
+<table><thead><tr><th width="245">Repository</th><th width="580">Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevm-solidity/">fhevm</a></td><td>Solidity library for FHE operations (e.g., encryption/decryption, arithmetic) within smart contracts.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-hardhat-template">fhevm-hardhat-template</a></td><td>Hardhat template with scripts for compiling, deploying, and testing FHE‐enabled contracts.</td></tr><tr><td>fhevm-foundry-template - <em>coming soon</em></td><td>Foundry template for building FHE smart contracts.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-contracts">fhevm-contracts</a></td><td>Ready‐to‐use FHE smart contract example covering finance, governance, and ERC‐20 tokens use cases.</td></tr></tbody></table>
 
 #### Frontend development
 
-<table><thead><tr><th width="252">Repository</th><th>Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevmjs/">@httpz/sdk</a></td><td>JavaScript library for client‐side FHE, enabling encryption, decryption, and data handling.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-react-template">fhevm-react-template</a></td><td>React.js template to quickly spin up FHE‐enabled dApps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-next-template">fhevm-next-template</a></td><td>Next.js template for integrating FHE in server‐side rendered or hybrid web apps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-vue-template">fhevm-vue-template</a></td><td>Vue.js template for creating privacy‐preserving dApps with encrypted data</td></tr></tbody></table>
+<table><thead><tr><th width="252">Repository</th><th>Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevmjs/">@fhevm/sdk</a></td><td>JavaScript library for client‐side FHE, enabling encryption, decryption, and data handling.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-react-template">fhevm-react-template</a></td><td>React.js template to quickly spin up FHE‐enabled dApps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-next-template">fhevm-next-template</a></td><td>Next.js template for integrating FHE in server‐side rendered or hybrid web apps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-vue-template">fhevm-vue-template</a></td><td>Vue.js template for creating privacy‐preserving dApps with encrypted data</td></tr></tbody></table>
 
 #### Examples & Resources
 
@@ -22,6 +22,6 @@ The HTTPZ Protocol provides a **`TFHE` Solidity library** for building confident
 
 ### For network builders
 
-To **integrate FHE at the protocol level** or operate an **FHE‐enabled network**, HTTPZ offers the HTTPZ backend modules. These repositories include the foundational implementations that enables FHE in blockchain systems, ensuring that privacy remains at the core of your network architecture.
+To **integrate FHE at the protocol level** or operate an **FHE‐enabled network**, fhevm offers the fhevm backend modules. These repositories include the foundational implementations that enables FHE in blockchain systems, ensuring that privacy remains at the core of your network architecture.
 
 <table><thead><tr><th width="260">Repository</th><th>Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevm-backend">fhevm-backend</a></td><td>Rust backend &#x26; Go‐Ethereum modules, enabling native or coprocessor‐based FHE.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-go/">fhevm-go</a></td><td>Go implementation of the FHE Virtual Machine</td></tr><tr><td><a href="https://github.com/zama-ai/zbc-go-ethereum/">zbc-go-ethereum</a></td><td>Modified go-ethereum with enhanced FHE support</td></tr></tbody></table>

--- a/docs/references/fhevmjs.md
+++ b/docs/references/fhevmjs.md
@@ -1,17 +1,17 @@
-# Frontend - @httpz/sdk lib
+# Frontend - @fhevm/sdk lib
 
-This document provides an overview of the `@httpz/sdk` library, detailing its initialization, instance creation, input handling, encryption, and re-encryption processes.
+This document provides an overview of the `@fhevm/sdk` library, detailing its initialization, instance creation, input handling, encryption, and re-encryption processes.
 
-[@httpz/sdk](https://github.com/zama-ai/fhevmjs/) is designed to assist in creating encrypted inputs and retrieving re-encryption data off-chain through a gateway. The library works with any HTTPZ Coprocessors.
+[@fhevm/sdk](https://github.com/zama-ai/fhevmjs/) is designed to assist in creating encrypted inputs and retrieving re-encryption data off-chain through a gateway. The library works with any fhevm Coprocessors.
 
 ## Init (browser)
 
-If you are using `@httpz/sdk` in a web application, you need to initialize it before creating an instance. To do this, you should call `initHTTPZ` and wait for the promise to resolve.
+If you are using `@fhevm/sdk` in a web application, you need to initialize it before creating an instance. To do this, you should call `initfhevm` and wait for the promise to resolve.
 
 ```javascript
-import { HTTPZInstance, createInstance } from "@httpz/sdk/node";
+import { fhevmInstance, createInstance } from "@fhevm/sdk/node";
 
-initHTTPZ().then(() => {
+initfhevm().then(() => {
   const instance = await createInstance({
     network: window.ethereum,
     gatewayUrl: "https://gateway.sepolia.zama.ai",
@@ -23,7 +23,7 @@ initHTTPZ().then(() => {
 
 ## Create instance
 
-This function returns an instance of @httpz/sdk, which accepts an object containing:
+This function returns an instance of @fhevm/sdk, which accepts an object containing:
 
 - `kmsContractAddress`: the address of the KMSVerifier contract;
 - `aclContractAddress`: the address of the ACL contract;
@@ -34,7 +34,7 @@ This function returns an instance of @httpz/sdk, which accepts an object contain
 - `publicParams` (optional): if the public params has been fetched separately or stored in cache, you can provide it
 
 ```javascript
-import { createInstance } from "@httpz/sdk";
+import { createInstance } from "@fhevm/sdk";
 
 const instance = await createInstance({
   networkUrl: "https://eth-sepolia.public.blastapi.io",
@@ -47,7 +47,7 @@ const instance = await createInstance({
 Using `window.ethereum` object:
 
 ```javascript
-import { HTTPZInstance, createInstance } from "@httpz/sdk/bundle";
+import { fhevmInstance, createInstance } from "@fhevm/sdk/bundle";
 
 const instance = await createInstance({
   network: window.ethereum,

--- a/docs/references/fhevmjs.md
+++ b/docs/references/fhevmjs.md
@@ -6,12 +6,12 @@ This document provides an overview of the `@fhevm/sdk` library, detailing its in
 
 ## Init (browser)
 
-If you are using `@fhevm/sdk` in a web application, you need to initialize it before creating an instance. To do this, you should call `initfhevm` and wait for the promise to resolve.
+If you are using `@fhevm/sdk` in a web application, you need to initialize it before creating an instance. To do this, you should call `initFhevm` and wait for the promise to resolve.
 
 ```javascript
 import { fhevmInstance, createInstance } from "@fhevm/sdk/node";
 
-initfhevm().then(() => {
+initFhevm().then(() => {
   const instance = await createInstance({
     network: window.ethereum,
     gatewayUrl: "https://gateway.sepolia.zama.ai",

--- a/docs/references/functions.md
+++ b/docs/references/functions.md
@@ -1,4 +1,4 @@
-# Smart contracts - HTTPZ API
+# Smart contracts - fhevm API
 
 This document provides an overview of the functions available in the `TFHE` Solidity library. The TFHE library provides functionality for working with encrypted types and performing operations on them. It implements fully homomorphic encryption (FHE) operations in Solidity.
 
@@ -94,7 +94,7 @@ The `asEbool` functions behave similarly to the `asEuint` functions, but for enc
 function setFHEVM(FHEVMConfig.FHEVMConfigStruct memory fhevmConfig) internal
 ```
 
-Sets the HTTPZ configuration for encrypted operations.
+Sets the fhevm configuration for encrypted operations.
 
 ### Initialization Checks
 

--- a/docs/references/repositories.md
+++ b/docs/references/repositories.md
@@ -30,11 +30,11 @@ Contribute to the development of FHE technologies and earn rewards through Zamaâ
 
 Access the essential libraries for building and integrating FHE-enabled applications:
 
-| **Repository**                                            | **Description**                                                 |
-| --------------------------------------------------------- | --------------------------------------------------------------- |
-| [httpz-solidity](https://github.com/zama-ai/fhevm/)       | Solidity library for FHE operations                             |
-| [@httpz/sdk](https://github.com/zama-ai/fhevmjs/)         | JavaScript library for client-side FHE                          |
-| [fhevm-backend](https://github.com/zama-ai/fhevm-backend) | Rust backend and go-ethereum modules for native and coprocessor |
+| **Repository**                                               | **Description**                                                 |
+| ------------------------------------------------------------ | --------------------------------------------------------------- |
+| [fhevm-solidity](https://github.com/zama-ai/fhevm-solidity/) | Solidity library for FHE operations                             |
+| [@fhevm/sdk](https://github.com/zama-ai/fhevmjs/)            | JavaScript library for client-side FHE                          |
+| [fhevm-backend](https://github.com/zama-ai/fhevm-backend)    | Rust backend and go-ethereum modules for native and coprocessor |
 
 ## **Core implementations**
 

--- a/docs/smart_contracts/acl/README.md
+++ b/docs/smart_contracts/acl/README.md
@@ -1,14 +1,14 @@
 # Access Control List
 
-This document describes the Access Control List (ACL) system in HTTPZ, a core feature that governs access to encrypted data. The ACL ensures that only authorized accounts or contracts can interact with specific ciphertexts, preserving confidentiality while enabling composable smart contracts. This overview provides a high-level understanding of what the ACL is, why it's essential, and how it works.
+This document describes the Access Control List (ACL) system in fhevm, a core feature that governs access to encrypted data. The ACL ensures that only authorized accounts or contracts can interact with specific ciphertexts, preserving confidentiality while enabling composable smart contracts. This overview provides a high-level understanding of what the ACL is, why it's essential, and how it works.
 
 ## What is the ACL?
 
-The ACL is a permission management system designed to control who can access, compute on, or decrypt encrypted values in HTTPZ. By defining and enforcing these permissions, the ACL ensures that encrypted data remains secure while still being usable within authorized contexts.
+The ACL is a permission management system designed to control who can access, compute on, or decrypt encrypted values in fhevm. By defining and enforcing these permissions, the ACL ensures that encrypted data remains secure while still being usable within authorized contexts.
 
 ## Why is the ACL important?
 
-Encrypted data in HTTPZ is entirely confidential, meaning that without proper access control, even the contract holding the ciphertext cannot interact with it. The ACL enables:
+Encrypted data in fhevm is entirely confidential, meaning that without proper access control, even the contract holding the ciphertext cannot interact with it. The ACL enables:
 
 - **Granular permissions**: Define specific access rules for individual accounts or contracts.
 - **Secure computations**: Ensure that only authorized entities can manipulate or decrypt encrypted data.

--- a/docs/smart_contracts/acl/acl_examples.md
+++ b/docs/smart_contracts/acl/acl_examples.md
@@ -1,6 +1,6 @@
 # ACL examples
 
-This page provides detailed instructions and examples on how to use and implement the ACL (Access Control List) in HTTPZ. For an overview of ACL concepts and their importance, refer to the [access control list (ACL) overview](./).
+This page provides detailed instructions and examples on how to use and implement the ACL (Access Control List) in fhevm. For an overview of ACL concepts and their importance, refer to the [access control list (ACL) overview](./).
 
 ---
 
@@ -168,4 +168,4 @@ function transfer(address to, euint64 encryptedAmount) public {
 
 ---
 
-By understanding how to grant and verify permissions, you can effectively manage access to encrypted data in your HTTPZ smart contracts. For additional context, see the [ACL overview](./).
+By understanding how to grant and verify permissions, you can effectively manage access to encrypted data in your fhevm smart contracts. For additional context, see the [ACL overview](./).

--- a/docs/smart_contracts/architecture_overview.md
+++ b/docs/smart_contracts/architecture_overview.md
@@ -1,6 +1,6 @@
 # Architectural overview
 
-The HTTPZ architecture provides the foundation for confidential smart contracts on EVM-compatible blockchains. At its core is FHE, a cryptographic technique enabling computations directly on encrypted data, ensuring privacy at every stage.&#x20;
+The fhevm architecture provides the foundation for confidential smart contracts on EVM-compatible blockchains. At its core is FHE, a cryptographic technique enabling computations directly on encrypted data, ensuring privacy at every stage.&#x20;
 
 This system relies on three key types:&#x20;
 
@@ -8,7 +8,7 @@ This system relies on three key types:&#x20;
 - The **private key:** used for decryption and securely managed by the Key Management System or KMS
 - The **evaluation key:** enabling encrypted computations performed by the coprocessor.
 
-The HTTPZ leverages Zama's TFHE library, integrating seamlessly with blockchain environments to address transparency, composability, and scalability challenges. Its hybrid architecture combines:
+The fhevm leverages Zama's TFHE library, integrating seamlessly with blockchain environments to address transparency, composability, and scalability challenges. Its hybrid architecture combines:
 
 - **On-chain smart contracts** for encrypted state management and access controls.
 - **Off-chain coprocessors** for resource-intensive FHE computations.
@@ -17,4 +17,4 @@ The HTTPZ leverages Zama's TFHE library, integrating seamlessly with blockchain 
 
 This architecture enables developers to write private, composable smart contracts using symbolic execution and zero-knowledge proofs, ensuring data confidentiality and computational integrity.
 
-For a detailed exploration of the HTTPZ architecture, including components, workflows, and deployment models, see [Architecture Overview](architecture_overview.md).
+For a detailed exploration of the fhevm architecture, including components, workflows, and deployment models, see [Architecture Overview](architecture_overview.md).

--- a/docs/smart_contracts/architecture_overview/fhe-on-blockchain.md
+++ b/docs/smart_contracts/architecture_overview/fhe-on-blockchain.md
@@ -1,6 +1,6 @@
 # FHE on blockchain
 
-This page gives an overview of Fully Homomorphic Encryption (FHE) and its implementation on the blockchain by HTTPZ. It provides the essential architectural concepts needed to start building with HTTPZ.
+This page gives an overview of Fully Homomorphic Encryption (FHE) and its implementation on the blockchain by fhevm. It provides the essential architectural concepts needed to start building with fhevm.
 
 ## **FHE overview**
 
@@ -16,31 +16,31 @@ FHE operates using three types of keys, each playing a crucial role in its funct
 ### **Private key**
 
 - **Purpose**: - for securely decrypting results - Decrypts ciphertexts to recover the original plaintext.
-- **Usage in HTTPZ**: Managed securely by the Key Management System (KMS) using a threshold MPC protocol. This ensures no single entity ever possesses the full private key.
+- **Usage in fhevm**: Managed securely by the Key Management System (KMS) using a threshold MPC protocol. This ensures no single entity ever possesses the full private key.
 
 ### **Public key**
 
 - **Purpose**: - for encrypting data. - Encrypts plaintexts into ciphertexts.
-- **Usage in HTTPZ**: Shared globally to allow users and smart contracts to encrypt inputs or states. It ensures that encrypted data can be processed without revealing the underlying information.
+- **Usage in fhevm**: Shared globally to allow users and smart contracts to encrypt inputs or states. It ensures that encrypted data can be processed without revealing the underlying information.
 
 ### **Evaluation key**
 
 - **Purpose**: - for performing encrypted computations - Enables efficient homomorphic operations (e.g., addition, multiplication) on ciphertexts.
-- **Usage in HTTPZ**: Provided to FHE nodes (on-chain validators or off-chain coprocessors) to perform computations on encrypted data while preserving confidentiality.
+- **Usage in fhevm**: Provided to FHE nodes (on-chain validators or off-chain coprocessors) to perform computations on encrypted data while preserving confidentiality.
 
-These three keys work together to facilitate private and secure computations, forming the foundation of FHE-based systems like HTTPZ.
+These three keys work together to facilitate private and secure computations, forming the foundation of FHE-based systems like fhevm.
 
 <figure><img src="../../.gitbook/assets/keys_fhe.png" alt="FHE Keys Overview"><figcaption><p>Overview of FHE Keys and their roles</p></figcaption></figure>
 
-## **FHE to Blockchain: From library to HTTPZ**
+## **FHE to Blockchain: From library to fhevm**
 
 ### **Building on Zama's FHE library**
 
-At its core, the HTTPZ is built on Zama's high-performance FHE library, **TFHE-rs**, written in Rust. This library implements the TFHE (Torus Fully Homomorphic Encryption) scheme and is designed to perform secure computations on encrypted data efficiently.
+At its core, the fhevm is built on Zama's high-performance FHE library, **TFHE-rs**, written in Rust. This library implements the TFHE (Torus Fully Homomorphic Encryption) scheme and is designed to perform secure computations on encrypted data efficiently.
 
 > **Info**: For detailed documentation and implementation examples on the `tfhe-rs` library, visit the [TFHE-rs documentation](https://docs.zama.ai/tfhe-rs).
 
-However, integrating a standalone FHE library like TFHE-rs into a blockchain environment involves unique challenges. Blockchain systems demand efficient processing, public verifiability, and seamless interoperability, all while preserving their decentralized nature. To address these requirements, Zama designed the HTTPZ, a system that bridges the computational power of TFHE-rs with the transparency and scalability of blockchain technology.
+However, integrating a standalone FHE library like TFHE-rs into a blockchain environment involves unique challenges. Blockchain systems demand efficient processing, public verifiability, and seamless interoperability, all while preserving their decentralized nature. To address these requirements, Zama designed the fhevm, a system that bridges the computational power of TFHE-rs with the transparency and scalability of blockchain technology.
 
 ### **Challenges in blockchain integration**
 
@@ -51,7 +51,7 @@ Integrating FHE into blockchain systems posed several challenges that needed to 
 3. **Composability**: Smart contracts needed to interact seamlessly with each other, even when operating on encrypted data.
 4. **Performance and scalability**: FHE computations are resource-intensive, and blockchain systems require high throughput to remain practical.
 
-To overcome these challenges, Zama introduced a hybrid architecture for HTTPZ that combines:
+To overcome these challenges, Zama introduced a hybrid architecture for fhevm that combines:
 
 - **On-chain** functionality for managing state and enforcing access controls.
 - **Off-chain** processing via a coprocessor to execute resource-intensive FHE computations.

--- a/docs/smart_contracts/architecture_overview/fhevm-components.md
+++ b/docs/smart_contracts/architecture_overview/fhevm-components.md
@@ -1,35 +1,35 @@
-# HTTPZ components
+# fhevm components
 
-This document gives a detailed explanantion of each component of HTTPZ and illustrate how they work together to perform computations.&#x20;
+This document gives a detailed explanantion of each component of fhevm and illustrate how they work together to perform computations.&#x20;
 
 ## Overview
 
-The HTTPZ architecture is built around four primary components, each contributing to the system's functionality and performance. These components work together to enable the development and execution of private, composable smart contracts on EVM-compatible blockchains. Below is an overview of these components and their responsibilities:
+The fhevm architecture is built around four primary components, each contributing to the system's functionality and performance. These components work together to enable the development and execution of private, composable smart contracts on EVM-compatible blockchains. Below is an overview of these components and their responsibilities:
 
-| [**HTTPZ Smart Contracts**](fhevm-components.md#fhevm-smart-contracts)           | Smart contracts deployed on the blockchain to manage encrypted data and interactions.                     | Includes the Access Control List (ACL) contract, `TFHE.sol` Solidity library, `Gateway.sol` and other FHE-enabled smart contracts. |
+| [**fhevm Smart Contracts**](fhevm-components.md#fhevm-smart-contracts)           | Smart contracts deployed on the blockchain to manage encrypted data and interactions.                     | Includes the Access Control List (ACL) contract, `TFHE.sol` Solidity library, `Gateway.sol` and other FHE-enabled smart contracts. |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [**Gateway**](fhevm-components.md#gateway)                                       | An off-chain service that bridges the blockchain with the cryptographic systems like KMS and coprocessor. | Acts as an intermediary to forward the necessary requests and results between the blockchain, the KMS, and users.                  |
 | [**Coprocessor**](fhevm-components.md#coprocessor)                               | An off-chain computational engine designed to execute resource-intensive FHE operations.                  | Executes symbolic FHE operations, manages ciphertext storage, and ensures efficient computation handling.                          |
 | [**Key Management System (KMS)**](fhevm-components.md#key-management-system-kms) | A decentralized cryptographic service that securely manages FHE keys and validates operations.            | Manages the global FHE key (public, private, evaluation), performs threshold decryption, and validates ZKPoKs.                     |
 
-<figure><img src="../../.gitbook/assets/architecture.png" alt="FHE Keys Overview"><figcaption><p>High level overview of the HTTPZ Architecture</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/architecture.png" alt="FHE Keys Overview"><figcaption><p>High level overview of the fhevm Architecture</p></figcaption></figure>
 
 ## **Developer workflow:**
 
-As a developer working with HTTPZ, your workflow typically involves two key elements:
+As a developer working with fhevm, your workflow typically involves two key elements:
 
 1. **Frontend development**:\
    You create a frontend interface for users to interact with your confidential application. This includes encrypting inputs using the public FHE key and submitting them to the blockchain.
 2. **Smart contract development**:\
-   You write Solidity contracts deployed on the same blockchain as the HTTPZ smart contracts. These contracts leverage the `TFHE.sol` library to perform operations on encrypted data. Below, we explore the major components involved.
+   You write Solidity contracts deployed on the same blockchain as the fhevm smart contracts. These contracts leverage the `TFHE.sol` library to perform operations on encrypted data. Below, we explore the major components involved.
 
-## **HTTPZ smart contracts**
+## **fhevm smart contracts**
 
-HTTPZ smart contracts include the Access Control List (ACL) contract, `TFHE.sol` library, and related FHE-enabled contracts.
+fhevm smart contracts include the Access Control List (ACL) contract, `TFHE.sol` library, and related FHE-enabled contracts.
 
 ### **Symbolic execution in Solidity**
 
-HTTPZ implements **symbolic execution** to optimize FHE computations:
+fhevm implements **symbolic execution** to optimize FHE computations:
 
 - **Handles**: Operations on encrypted data return "handles" (references to ciphertexts) instead of immediate results.
 - **Lazy Execution**: Actual computations are performed asynchronously, offloading resource-intensive tasks to the coprocessor.
@@ -38,12 +38,12 @@ This approach ensures high throughput and flexibility in managing encrypted data
 
 ### **Zero-Knowledge proofs of knowledge (ZKPoKs)**
 
-HTTPZ incorporates ZKPoKs to verify the correctness of encrypted inputs and outputs:
+fhevm incorporates ZKPoKs to verify the correctness of encrypted inputs and outputs:
 
 - **Validation**: ZKPoKs ensure that inputs are correctly formed and correspond to known plaintexts without revealing sensitive data.
 - **Integrity**: They prevent misuse of ciphertexts and ensure the correctness of computations.
 
-By combining symbolic execution and ZKPoKs, HTTPZ smart contracts maintain both privacy and verifiability.
+By combining symbolic execution and ZKPoKs, fhevm smart contracts maintain both privacy and verifiability.
 
 ## **Coprocessor**
 
@@ -68,7 +68,7 @@ The Gateway simplifies the development process by abstracting the complexity of 
 
 ## **Key management system (KMS)**
 
-The KMS securely manages the cryptographic backbone of HTTPZ by maintaining and distributing the global FHE keys.
+The KMS securely manages the cryptographic backbone of fhevm by maintaining and distributing the global FHE keys.
 
 ### **Key functions**:
 

--- a/docs/smart_contracts/asEXXoperators.md
+++ b/docs/smart_contracts/asEXXoperators.md
@@ -1,6 +1,6 @@
 # asEbool, asEuintXX, asEaddress and asEbytesXX operations
 
-This documentation covers the `asEbool`, `asEuintXX`, `asEaddress` and `asEbytesXX` operations provided by the TFHE library for working with encrypted data in the HTTPZ. These operations are essential for converting between plaintext and encrypted types, as well as handling encrypted inputs.
+This documentation covers the `asEbool`, `asEuintXX`, `asEaddress` and `asEbytesXX` operations provided by the TFHE library for working with encrypted data in the fhevm. These operations are essential for converting between plaintext and encrypted types, as well as handling encrypted inputs.
 
 The operations can be categorized into three main use cases:
 

--- a/docs/smart_contracts/conditions.md
+++ b/docs/smart_contracts/conditions.md
@@ -1,12 +1,12 @@
 # Branching in FHE
 
-This document explains how to implement conditional logic (if/else branching) when working with encrypted values in HTTPZ. Unlike typical Solidity programming, working with Fully Homomorphic Encryption (FHE) requires specialized methods to handle conditions on encrypted data.
+This document explains how to implement conditional logic (if/else branching) when working with encrypted values in fhevm. Unlike typical Solidity programming, working with Fully Homomorphic Encryption (FHE) requires specialized methods to handle conditions on encrypted data.
 
 ## **Overview**
 
-In HTTPZ, when you perform [comparison operations](../references/functions.md#comparison-operation-eq-ne-ge-gt-le-lt), the result is an encrypted boolean (`ebool`). Since encrypted booleans do not support standard boolean operations like `if` statements or logical operators, conditional logic must be implemented using specialized methods.
+In fhevm, when you perform [comparison operations](../references/functions.md#comparison-operation-eq-ne-ge-gt-le-lt), the result is an encrypted boolean (`ebool`). Since encrypted booleans do not support standard boolean operations like `if` statements or logical operators, conditional logic must be implemented using specialized methods.
 
-To facilitate conditional assignments, HTTPZ provides the `TFHE.select` function, which acts as a ternary operator for encrypted values.
+To facilitate conditional assignments, fhevm provides the `TFHE.select` function, which acts as a ternary operator for encrypted values.
 
 ## **Using `TFHE.select` for conditional logic**
 
@@ -41,7 +41,7 @@ function bid(einput encryptedValue, bytes calldata inputProof) external onlyBefo
 ```
 
 {% hint style="info" %}
-This is a simplified example to demonstrate the functionality. For a complete implementation with proper error handling and additional features, see the [Blind Auction contract example](https://github.com/zama-ai/fhevm/blob/29fe1f12236010737d86df156dc22eb6dedd0caa/examples/BlindAuction.sol#L92-L143).
+This is a simplified example to demonstrate the functionality. For a complete implementation with proper error handling and additional features, see the [Blind Auction contract example](https://github.com/zama-ai/fhevm-solidity/blob/29fe1f12236010737d86df156dc22eb6dedd0caa/examples/BlindAuction.sol#L92-L143).
 {% endhint %}
 
 ### **How It Works**
@@ -67,4 +67,4 @@ This is a simplified example to demonstrate the functionality. For a complete im
 - Encrypted booleans (`ebool`) and values maintain confidentiality, enabling privacy-preserving logic.
 - Developers should account for gas costs and ciphertext behavior when designing conditional operations.
 
-For more information on the supported operations, see the [HTTPZ API documentation](../references/functions.md).
+For more information on the supported operations, see the [fhevm API documentation](../references/functions.md).

--- a/docs/smart_contracts/configure.md
+++ b/docs/smart_contracts/configure.md
@@ -1,10 +1,10 @@
 # Configuration
 
-This document explains how to enable encrypted computations in your smart contract by setting up the `HTTPZ` environment. Learn how to integrate essential libraries, configure encryption, and add secure computation logic to your contracts.
+This document explains how to enable encrypted computations in your smart contract by setting up the `fhevm` environment. Learn how to integrate essential libraries, configure encryption, and add secure computation logic to your contracts.
 
 ## Core configuration setup
 
-To utilize encrypted computations in Solidity contracts, you must configure the **TFHE library** and **Gateway addresses**. The `httpz` package simplifies this process with prebuilt configuration contracts, allowing you to focus on developing your contract’s logic without handling the underlying cryptographic setup.
+To utilize encrypted computations in Solidity contracts, you must configure the **TFHE library** and **Gateway addresses**. The `fhevm` package simplifies this process with prebuilt configuration contracts, allowing you to focus on developing your contract’s logic without handling the underlying cryptographic setup.
 
 ## Key components configured automatically
 
@@ -16,7 +16,7 @@ By inheriting these configuration contracts, you ensure seamless initialization 
 
 ## ZamaFHEVMConfig.sol
 
-This configuration contract initializes the **HTTPZ environment** with required encryption parameters.
+This configuration contract initializes the **fhevm environment** with required encryption parameters.
 
 **Import based on your environment:**
 
@@ -28,7 +28,7 @@ import { SepoliaZamaFHEVMConfig } from "fhevm/config/ZamaFHEVMConfig.sol";
 **Purpose:**
 
 - Sets encryption parameters such as cryptographic keys and supported ciphertext types.
-- Ensures proper initialization of the HTTPZ environment.
+- Ensures proper initialization of the fhevm environment.
 
 **Example: using Sepolia configuration**
 
@@ -71,7 +71,7 @@ import "fhevm/gateway/GatewayCaller.sol";
 
 contract Test is SepoliaZamaFHEVMConfig, SepoliaZamaGatewayConfig, GatewayCaller {
   constructor() {
-    // Gateway and HTTPZ environment initialized automatically
+    // Gateway and fhevm environment initialized automatically
   }
 }
 ```

--- a/docs/smart_contracts/contracts.md
+++ b/docs/smart_contracts/contracts.md
@@ -1,10 +1,10 @@
 # fhevm-contracts
 
-This guide explains how to use the [HTTPZ Contracts standard library](https://github.com/zama-ai/fhevm-contracts/tree/main). This library provides secure, extensible, and pre-tested Solidity templates designed for developing smart contracts on HTTPZ using the TFHE library.
+This guide explains how to use the [fhevm Contracts standard library](https://github.com/zama-ai/fhevm-contracts/tree/main). This library provides secure, extensible, and pre-tested Solidity templates designed for developing smart contracts on fhevm using the TFHE library.
 
 ## Overview
 
-The **HTTPZ Contracts standard library** streamlines the development of confidential smart contracts by providing templates and utilities for tokens, governance, and error management. These contracts have been rigorously tested by Zama's engineers and are designed to accelerate development while enhancing security.
+The **fhevm Contracts standard library** streamlines the development of confidential smart contracts by providing templates and utilities for tokens, governance, and error management. These contracts have been rigorously tested by Zama's engineers and are designed to accelerate development while enhancing security.
 
 ## Installation
 

--- a/docs/smart_contracts/d_re_ecrypt_compute.md
+++ b/docs/smart_contracts/d_re_ecrypt_compute.md
@@ -1,8 +1,8 @@
 # Encryption, decryption, re-encryption, and computation
 
-This document introduces the core cryptographic operations in the HTTPZ system, including how data is encrypted, decrypted, re-encrypted and computed upon while maintaining privacy.
+This document introduces the core cryptographic operations in the fhevm system, including how data is encrypted, decrypted, re-encrypted and computed upon while maintaining privacy.
 
-The HTTPZ system ensures end-to-end confidentiality by leveraging Fully Homomorphic Encryption (FHE). The encryption, decryption, re-encryption, and computation processes rely on a coordinated flow of information and cryptographic keys across the HTTPZ components. This section details how these operations work and outlines the role of the FHE keys in enabling secure and private processing.
+The fhevm system ensures end-to-end confidentiality by leveraging Fully Homomorphic Encryption (FHE). The encryption, decryption, re-encryption, and computation processes rely on a coordinated flow of information and cryptographic keys across the fhevm components. This section details how these operations work and outlines the role of the FHE keys in enabling secure and private processing.
 
 ## **FHE keys and their locations**
 
@@ -16,13 +16,13 @@ The HTTPZ system ensures end-to-end confidentiality by leveraging Fully Homomorp
    - **Location**: Stored on the coprocessor.
    - **Role**: Enables operations on ciphertexts (e.g., addition, multiplication) without decrypting them.
 
-<figure><img src="../.gitbook/assets/architecture.png" alt="FHE Keys Overview"><figcaption><p>High level overview of the HTTPZ Architecture</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/architecture.png" alt="FHE Keys Overview"><figcaption><p>High level overview of the fhevm Architecture</p></figcaption></figure>
 
 ## **Workflow: encryption, decryption, and processing**
 
 ### **Encryption**
 
-Encryption is the starting point for any interaction with the HTTPZ system, ensuring that data is protected before it is transmitted or processed.
+Encryption is the starting point for any interaction with the fhevm system, ensuring that data is protected before it is transmitted or processed.
 
 - **How It Works**:
   1. The **frontend** or client application uses the **public key** to encrypt user-provided plaintext inputs.
@@ -94,7 +94,7 @@ Re-encryption enables encrypted data to be securely shared or reused under a dif
 
 #### Client-side implementation
 
-Re-encryption is initiated on the client side via the **Gateway service** using the [`@httpz/sdk`](https://github.com/zama-ai/fhevmjs/) library. Here’s the general workflow:
+Re-encryption is initiated on the client side via the **Gateway service** using the [`@fhevm/sdk`](https://github.com/zama-ai/fhevmjs/) library. Here’s the general workflow:
 
 1. **Retrieve the ciphertext**:
    - The dApp calls a view function (e.g., `balanceOf`) on the smart contract to get the handle of the ciphertext to be re-encrypted.
@@ -116,7 +116,7 @@ You can read [our re-encryption guide explaining how to use it](decryption/reenc
 
 ## **Tying It All Together**
 
-The flow of information across the HTTPZ components during these operations highlights how the system ensures privacy while maintaining usability:
+The flow of information across the fhevm components during these operations highlights how the system ensures privacy while maintaining usability:
 
 | Operation         |                         |                                                                                                                                                                                 |
 | ----------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -125,4 +125,4 @@ The flow of information across the HTTPZ components during these operations high
 | **Decryption**    | Private Key             | Blockchain or Gateway sends ciphertext to KMS → KMS decrypts using private key → Plaintext returned to authorized requester (e.g., frontend or specific user).                  |
 | **Re-encryption** | Private and Target Keys | Blockchain or Gateway sends ciphertext to KMS → KMS re-encrypts using private key and target key → Updated ciphertext returned to blockchain, frontend, or other contract/user. |
 
-This architecture ensures that sensitive data remains encrypted throughout its lifecycle, with decryption or re-encryption only occurring in controlled, secure environments. By separating key roles and processing responsibilities, HTTPZ provides a scalable and robust framework for private smart contracts.
+This architecture ensures that sensitive data remains encrypted throughout its lifecycle, with decryption or re-encryption only occurring in controlled, secure environments. By separating key roles and processing responsibilities, fhevm provides a scalable and robust framework for private smart contracts.

--- a/docs/smart_contracts/debug_decrypt.md
+++ b/docs/smart_contracts/debug_decrypt.md
@@ -1,6 +1,6 @@
 # Debugging with `debug.decrypt[XX]`
 
-This guide explains how to use the `debug.decrypt[XX]` functions for debugging encrypted data in mocked environments during development with HTTPZ.
+This guide explains how to use the `debug.decrypt[XX]` functions for debugging encrypted data in mocked environments during development with fhevm.
 
 {% hint style="warning" %}
 The `debug.decrypt[XX]` functions should not be used in production as they rely on private keys.

--- a/docs/smart_contracts/decryption/decrypt.md
+++ b/docs/smart_contracts/decryption/decrypt.md
@@ -1,6 +1,6 @@
 # Decryption
 
-This section explains how to handle decryption in HTTPZ. Decryption allows plaintext data to be accessed when required for contract logic or user presentation, ensuring confidentiality is maintained throughout the process.
+This section explains how to handle decryption in fhevm. Decryption allows plaintext data to be accessed when required for contract logic or user presentation, ensuring confidentiality is maintained throughout the process.
 
 {% hint style="info" %}
 Understanding how encryption, decryption and reencryption works is a prerequisit before implementation, see [Encryption, Decryption, Re-encryption, and Computation](../d_re_ecrypt_compute.md).
@@ -15,7 +15,7 @@ To learn how decryption works see [Encryption, Decryption, Re-encryption, and Co
 
 ## Overview
 
-Decryption in HTTPZ is an asynchronous process that involves the Gateway and Key Management System (KMS). Contracts requiring decryption must extend the GatewayCaller contract, which imports the necessary libraries and provides access to the Gateway.
+Decryption in fhevm is an asynchronous process that involves the Gateway and Key Management System (KMS). Contracts requiring decryption must extend the GatewayCaller contract, which imports the necessary libraries and provides access to the Gateway.
 
 Here’s an example of how to request decryption in a contract:
 
@@ -52,7 +52,7 @@ contract TestAsyncDecrypt is SepoliaZamaFHEVMConfig, SepoliaZamaGatewayConfig, G
 
 #### Key additions to the code
 
-1.  **Configuration imports**: The configuration contracts are imported to set up the HTTPZ environment and Gateway.
+1.  **Configuration imports**: The configuration contracts are imported to set up the fhevm environment and Gateway.
 
     ```solidity
     import { SepoliaZamaFHEVMConfig } from "fhevm/config/ZamaFHEVMConfig.sol";

--- a/docs/smart_contracts/decryption/reencryption.md
+++ b/docs/smart_contracts/decryption/reencryption.md
@@ -2,7 +2,7 @@
 
 This document explains how to perform re-encryption. Re-encryption is required when you want a user to access their private data without it being exposed to the blockchain.
 
-Re-encryption in HTTPZ enables the secure sharing or reuse of encrypted data under a new public key without exposing the plaintext. This feature is essential for scenarios where encrypted data must be transferred between contracts, dApps, or users while maintaining its confidentiality.
+Re-encryption in fhevm enables the secure sharing or reuse of encrypted data under a new public key without exposing the plaintext. This feature is essential for scenarios where encrypted data must be transferred between contracts, dApps, or users while maintaining its confidentiality.
 
 {% hint style="info" %}
 Before implementing re-encryption, ensure you are familiar with the foundational concepts of encryption, re-encryption and computation. Refer to [Encryption, Decryption, Re-encryption, and Computation](../d_re_ecrypt_compute.md).
@@ -43,14 +43,14 @@ Here, `balanceOf` allows retrieval of the user’s encrypted balance stored on t
 
 ## Step 2: re-encrypt the ciphertext
 
-Re-encryption is performed client-side using the `@httpz/sdk` library. [Refer to the guide](../../frontend/webapp.md) to learn how to include `@httpz/sdk` in your project.
+Re-encryption is performed client-side using the `@fhevm/sdk` library. [Refer to the guide](../../frontend/webapp.md) to learn how to include `@fhevm/sdk` in your project.
 Below is an example of how to implement reencryption in a dApp:
 
 ```ts
 import { createInstances } from "../instance";
 import { getSigners, initSigners } from "../signers";
 import abi from "./abi.json";
-import { createInstance } from "@httpz/sdk/bundle";
+import { createInstance } from "@fhevm/sdk/bundle";
 import { Contract, BrowserProvider } from "ethers";
 
 const CONTRACT_ADDRESS = "";

--- a/docs/smart_contracts/error_handling.md
+++ b/docs/smart_contracts/error_handling.md
@@ -1,6 +1,6 @@
 # Error handling
 
-This document explains how to handle errors effectively in HTTPZ smart contracts. Since transactions involving encrypted data do not automatically revert when conditions are not met, developers need alternative mechanisms to communicate errors to users.
+This document explains how to handle errors effectively in fhevm smart contracts. Since transactions involving encrypted data do not automatically revert when conditions are not met, developers need alternative mechanisms to communicate errors to users.
 
 ## **Challenges in error handling**
 

--- a/docs/smart_contracts/gas.md
+++ b/docs/smart_contracts/gas.md
@@ -1,22 +1,22 @@
-# Gas estimation in HTTPZ
+# Gas estimation in fhevm
 
-This guide explains how to estimate gas costs for Fully Homomorphic Encryption (FHE) operations in your smart contracts on HTTPZ. Understanding gas consumption is critical for designing efficient confidential smart contracts.
+This guide explains how to estimate gas costs for Fully Homomorphic Encryption (FHE) operations in your smart contracts on fhevm. Understanding gas consumption is critical for designing efficient confidential smart contracts.
 
 ## Overview
 
-FHE operations in HTTPZ are computationally intensive, resulting in higher gas costs compared to standard Ethereum operations. This is due to the complex mathematical operations required to ensure privacy and security.
+FHE operations in fhevm are computationally intensive, resulting in higher gas costs compared to standard Ethereum operations. This is due to the complex mathematical operations required to ensure privacy and security.
 
-### Types of gas in HTTPZ
+### Types of gas in fhevm
 
 1. **Native Gas**:
    - Standard gas used for operations on the underlying EVM chain.
-   - On HTTPZ, native gas consumption is approximately 20% higher than in mocked environments.
+   - On fhevm, native gas consumption is approximately 20% higher than in mocked environments.
 2. **FHEGas**:
    - Represents gas consumed by FHE-specific computations.
    - A new synthetic kind of gas consumed by FHE-specific computations.
    - FHEGas is tracked in each block by the FHEGasLimit contract to prevent DDOS attacks.
    - If too many FHE operations are requested in the same block, the transaction will revert once the FHEGas block limit is reached.
-   - FHEGas is consistent across both mocked and real HTTPZ environments.
+   - FHEGas is consistent across both mocked and real fhevm environments.
 
 > **Note**: Gas values provided are approximate and may vary based on network conditions, implementation details, and contract complexity.
 
@@ -29,13 +29,13 @@ To monitor gas usage during development, use the following tools:
 - **`getFHEGasFromTxReceipt`**:
 
   - Extracts FHEGas consumption from a transaction receipt.
-  - Works only in mocked HTTPZ environments, but gives the exact same value as in non-mocked environments.
+  - Works only in mocked fhevm environments, but gives the exact same value as in non-mocked environments.
   - Import as: `import { getFHEGasFromTxReceipt } from "../coprocessorUtils";`
 
 - **`.gasUsed` from ethers.js transaction receipt**:
   - Standard ethers.js transaction receipt property that returns the native gas used.
   - In mocked mode, this value underestimates real native gas usage by ~20%.
-  - Works in both mocked and real HTTPZ environments, as it's a standard Ethereum transaction property.
+  - Works in both mocked and real fhevm environments, as it's a standard Ethereum transaction property.
 
 ### Example: gas measurement
 

--- a/docs/smart_contracts/inputs.md
+++ b/docs/smart_contracts/inputs.md
@@ -1,12 +1,12 @@
 # Encrypted Inputs
 
-This document introduces the concept of encrypted inputs in the HTTPZ, explaining their role, structure, validation process, and how developers can integrate them into smart contracts and applications.
+This document introduces the concept of encrypted inputs in the fhevm, explaining their role, structure, validation process, and how developers can integrate them into smart contracts and applications.
 
 {% hint style="info" %}
 Understanding how encryption, decryption and reencryption works is a prerequisite before implementation, see [Encryption, Decryption, Re-encryption, and Computation](d_re_ecrypt_compute.md)
 {% endhint %}
 
-Encrypted inputs are a core feature of HTTPZ, enabling users to push encrypted data onto the blockchain while ensuring data confidentiality and integrity.
+Encrypted inputs are a core feature of fhevm, enabling users to push encrypted data onto the blockchain while ensuring data confidentiality and integrity.
 
 ## What are encrypted inputs?
 
@@ -45,7 +45,7 @@ In this example, `param1`, `param2`, and `param3` are encrypted inputs, while `i
 
 ## Client-Side implementation
 
-To interact with such a function, developers can use the [@httpz/sdk](https://github.com/zama-ai/fhevmjs) library to create and manage encrypted inputs. Below is an example implementation:
+To interact with such a function, developers can use the [@fhevm/sdk](https://github.com/zama-ai/fhevmjs) library to create and manage encrypted inputs. Below is an example implementation:
 
 ```javascript
 import { createInstances } from "../instance";
@@ -144,4 +144,4 @@ function transfer(
 - **Frontend encryption**: Always encrypt inputs using the FHE public key on the client side to ensure data confidentiality.
 - **Proof management**: Ensure that the correct zero-knowledge proof is associated with each encrypted input to avoid validation errors.
 
-Encrypted inputs and their validation form the backbone of secure and private interactions in the HTTPZ. By leveraging these tools, developers can create robust, privacy-preserving smart contracts without compromising functionality or scalability.
+Encrypted inputs and their validation form the backbone of secure and private interactions in the fhevm. By leveraging these tools, developers can create robust, privacy-preserving smart contracts without compromising functionality or scalability.

--- a/docs/smart_contracts/key_concepts.md
+++ b/docs/smart_contracts/key_concepts.md
@@ -1,10 +1,10 @@
 # Key features
 
-This document provides an overview of key features of the HTTPZ smart contract library.
+This document provides an overview of key features of the fhevm smart contract library.
 
 ### Configuration and initialization
 
-Smart contracts using HTTPZ require proper configuration and initialization:
+Smart contracts using fhevm require proper configuration and initialization:
 
 - **Environment setup**: Import and inherit from environment-specific configuration contracts
 - **Gateway configuration**: Configure secure gateway access for cryptographic operations
@@ -14,7 +14,7 @@ For more information see [Configuration](configure.md).
 
 ### Encrypted data types
 
-HTTPZ introduces encrypted data types compatible with Solidity:
+fhevm introduces encrypted data types compatible with Solidity:
 
 - **Booleans**: `ebool`
 - **Unsigned Integers**: `euint8`, `euint16`, `euint32`, `euint64`, `euint128`, `euint256`
@@ -28,7 +28,7 @@ For more information see [use of encrypted types](types.md).
 
 ### Casting types
 
-HTTPZ provides functions to cast between encrypted types:
+fhevm provides functions to cast between encrypted types:
 
 - **Casting between encrypted types**: `TFHE.asEbool` converts encrypted integers to encrypted booleans
 - **Casting to encrypted types**: `TFHE.asEuintX` converts plaintext values to encrypted types
@@ -39,7 +39,7 @@ For more information see [use of encrypted types](types.md).
 
 ### Confidential computation
 
-HTTPZ enables symbolic execution of encrypted operations, supporting:
+fhevm enables symbolic execution of encrypted operations, supporting:
 
 - **Arithmetic:** `TFHE.add`, `TFHE.sub`, `TFHE.mul`, `TFHE.min`, `TFHE.max`, `TFHE.neg`, `TFHE.div`, `TFHE.rem`
   - Note: `div` and `rem` operations are supported only with plaintext divisors
@@ -55,7 +55,7 @@ For more information on random number generation, see [Generate Random Encrypted
 
 ### Access control mechanism
 
-HTTPZ enforces access control with a blockchain-based Access Control List (ACL):
+fhevm enforces access control with a blockchain-based Access Control List (ACL):
 
 - **Persistent access**: `TFHE.allow`, `TFHE.allowThis` grants permanent permissions for ciphertexts.
 - **Transient access**: `TFHE.allowTransient` provides temporary access for specific transactions.

--- a/docs/smart_contracts/mocked.md
+++ b/docs/smart_contracts/mocked.md
@@ -1,10 +1,10 @@
 # Mocked mode
 
-This document provides an overview of mocked mode in the HTTPZ framework, explaining how it enables faster development and testing of smart contracts that use Fully Homomorphic Encryption (FHE).
+This document provides an overview of mocked mode in the fhevm framework, explaining how it enables faster development and testing of smart contracts that use Fully Homomorphic Encryption (FHE).
 
 ## Overview
 
-**Mocked mode** is a development and testing feature provided in the HTTPZ framework that allows developers to simulate the behavior of Fully Homomorphic Encryption (FHE) without requiring the full encryption and decryption processes to be performed. This makes development and testing cycles faster and more efficient by replacing actual cryptographic operations with mocked values, which behave similarly to encrypted data but without the computational overhead of true encryption.
+**Mocked mode** is a development and testing feature provided in the fhevm framework that allows developers to simulate the behavior of Fully Homomorphic Encryption (FHE) without requiring the full encryption and decryption processes to be performed. This makes development and testing cycles faster and more efficient by replacing actual cryptographic operations with mocked values, which behave similarly to encrypted data but without the computational overhead of true encryption.
 
 ## How to use mocked mode
 
@@ -20,17 +20,17 @@ Mocked mode support is planned for [Foundry](./write_contract/foundry.md) in fut
 
 ## How mocked mode works
 
-For faster testing iterations, instead of launching all the tests on the local HTTPZ node, which could last several minutes, you can use a mocked version of the HTTPZ by running `pnpm test`. The same tests should (almost always) pass as is, without any modification; neither the JavaScript files nor the Solidity files need to be changed between the mocked and the real version.
+For faster testing iterations, instead of launching all the tests on the local fhevm node, which could last several minutes, you can use a mocked version of the fhevm by running `pnpm test`. The same tests should (almost always) pass as is, without any modification; neither the JavaScript files nor the Solidity files need to be changed between the mocked and the real version.
 
-The mocked mode does **not** actually perform real encryption for encrypted types and instead runs the tests on a local Hardhat node, which is implementing the original EVM (i.e., non-HTTPZ).
+The mocked mode does **not** actually perform real encryption for encrypted types and instead runs the tests on a local Hardhat node, which is implementing the original EVM (i.e., non-fhevm).
 
 Additionally, the mocked mode will let you use all the Hardhat-related special testing and debugging methods, such as `evm_mine`, `evm_snapshot`, `evm_revert`, etc., which are very helpful for testing.
 
 ## Development workflow with mocked mode
 
-When developing confidential contracts, we recommend to use first the mocked version of HTTPZ for faster testing with `pnpm test` and coverage computation via `pnpm coverage`, this will lead to a better developer experience.
+When developing confidential contracts, we recommend to use first the mocked version of fhevm for faster testing with `pnpm test` and coverage computation via `pnpm coverage`, this will lead to a better developer experience.
 
-It's essential to run tests of the final contract version using the real HTTPZ. You can do this by running `pnpm test` before deployment.
+It's essential to run tests of the final contract version using the real fhevm. You can do this by running `pnpm test` before deployment.
 
 To run the mocked tests use either:
 

--- a/docs/smart_contracts/operations.md
+++ b/docs/smart_contracts/operations.md
@@ -128,7 +128,7 @@ Despite both leading to the same encrypted result!
 
 ### Beware of overflows of TFHE arithmetic operators
 
-TFHE arithmetic operators can overflow. Do not forget to take into account such a possibility when implementing HTTPZ smart contracts.
+TFHE arithmetic operators can overflow. Do not forget to take into account such a possibility when implementing fhevm smart contracts.
 
 ❌ For example, if you wanted to create a mint function for an encrypted ERC20 token with an encrypted `totalSupply` state variable, this code is vulnerable to overflows:
 
@@ -161,8 +161,8 @@ Notice that we did not check separately the overflow on `balances[msg.sender]` b
 
 ## Additional Resources
 
-- For detailed API specifications, visit the [HTTPZ API Documentation](../references/functions.md).
-- Check our [Roadmap](../developer/roadmap.md) for upcoming features or submit a feature request on [GitHub](https://github.com/zama-ai/fhevm/issues/new?template=feature-request.md).
+- For detailed API specifications, visit the [fhevm API Documentation](../references/functions.md).
+- Check our [Roadmap](../developer/roadmap.md) for upcoming features or submit a feature request on [GitHub](https://github.com/zama-ai/fhevm-solidity/issues/new?template=feature-request.md).
 - Join the discussion on the [Community Forum](https://community.zama.ai/c/fhevm/15).
 
 {% hint style="success" %}

--- a/docs/smart_contracts/random.md
+++ b/docs/smart_contracts/random.md
@@ -1,6 +1,6 @@
 # Generate random numbers
 
-This document explains how to generate cryptographically secure random encrypted numbers fully on-chain using the `TFHE` library in HTTPZ. These numbers are encrypted and remain confidential, enabling privacy-preserving smart contract logic.
+This document explains how to generate cryptographically secure random encrypted numbers fully on-chain using the `TFHE` library in fhevm. These numbers are encrypted and remain confidential, enabling privacy-preserving smart contract logic.
 
 ## **Key notes on random number generation**
 

--- a/docs/smart_contracts/types.md
+++ b/docs/smart_contracts/types.md
@@ -1,6 +1,6 @@
 # Supported types
 
-This document introduces the encrypted integer types provided by the `TFHE` library in HTTPZ and explains their usage, including casting, state variable declarations, and type-specific considerations.
+This document introduces the encrypted integer types provided by the `TFHE` library in fhevm and explains their usage, including casting, state variable declarations, and type-specific considerations.
 
 ## Introduction
 
@@ -16,7 +16,7 @@ The `TFHE` library offers a robust type system with encrypted integer types, ena
 Encrypted integers with overflow checking will soon be available in the `TFHE` library. These will allow reversible arithmetic operations but may reveal some information about the input values.
 {% endhint %}
 
-Encrypted integers in HTTPZ are represented as FHE ciphertexts, abstracted using ciphertext handles. These types, prefixed with `e` (for example, `euint64`) act as secure wrappers over the ciphertext handles.
+Encrypted integers in fhevm are represented as FHE ciphertexts, abstracted using ciphertext handles. These types, prefixed with `e` (for example, `euint64`) act as secure wrappers over the ciphertext handles.
 
 ## List of encrypted types
 
@@ -43,5 +43,5 @@ The `TFHE` library currently supports the following encrypted types:
 | `eint256`   | No, coming soon       |
 
 {% hint style="info" %}
-Higher-precision integer types are available in the `TFHE-rs` library and can be added to `HTTPZ` as needed.
+Higher-precision integer types are available in the `TFHE-rs` library and can be added to `fhevm` as needed.
 {% endhint %}

--- a/docs/smart_contracts/write_contract/foundry.md
+++ b/docs/smart_contracts/write_contract/foundry.md
@@ -1,7 +1,7 @@
 # Foundry
 
-This guide explains how to use Foundry with HTTPZ for developing smart contracts.
+This guide explains how to use Foundry with fhevm for developing smart contracts.
 
-While a Foundry template is currently in development, we strongly recommend using the [Hardhat template](https://github.com/zama-ai/fhevm-hardhat-template) for now, as it provides a fully tested and supported development environment for HTTPZ smart contracts.
+While a Foundry template is currently in development, we strongly recommend using the [Hardhat template](https://github.com/zama-ai/fhevm-hardhat-template) for now, as it provides a fully tested and supported development environment for fhevm smart contracts.
 
-However, you could still use Foundry with the mocked version of the HTTPZ, but please be aware that this approach is **NOT** recommended, since the mocked version is not fully equivalent to the real HTTPZ node's implementation (see warning in hardhat). In order to do this, you will need to rename your `TFHE.sol` imports from `fhevm/lib/TFHE.sol` to `fhevm/mocks/TFHE.sol` in your solidity source files.
+However, you could still use Foundry with the mocked version of the fhevm, but please be aware that this approach is **NOT** recommended, since the mocked version is not fully equivalent to the real fhevm node's implementation (see warning in hardhat). In order to do this, you will need to rename your `TFHE.sol` imports from `fhevm/lib/TFHE.sol` to `fhevm/mocks/TFHE.sol` in your solidity source files.

--- a/docs/tutorials/see-all-tutorials.md
+++ b/docs/tutorials/see-all-tutorials.md
@@ -2,7 +2,7 @@
 
 ## Solidity smart contracts templates - `fhevm-contracts`
 
-The [fhevm-contracts repository](https://github.com/zama-ai/fhevm-contracts) provides a comprehensive collection of secure, pre-tested Solidity templates optimized for HTTPZ development. These templates leverage the TFHE library to enable encrypted computations while maintaining security and extensibility.
+The [fhevm-contracts repository](https://github.com/zama-ai/fhevm-contracts) provides a comprehensive collection of secure, pre-tested Solidity templates optimized for fhevm development. These templates leverage the TFHE library to enable encrypted computations while maintaining security and extensibility.
 
 The library includes templates for common use cases like tokens and governance, allowing developers to quickly build confidential smart contracts with battle-tested components. For detailed implementation guidance and best practices, refer to the [contracts standard library guide](../smart_contracts/contracts.md).
 
@@ -36,7 +36,7 @@ The library includes templates for common use cases like tokens and governance, 
 
 ## Blog tutorials
 
-- [Suffragium: An Encrypted Onchain Voting System Leveraging ZK and FHE Using HTTPZ](https://www.zama.ai/post/encrypted-onchain-voting-using-zk-and-fhe-with-zama-fhevm) - Nov 2024
+- [Suffragium: An Encrypted Onchain Voting System Leveraging ZK and FHE Using fhevm](https://www.zama.ai/post/encrypted-onchain-voting-using-zk-and-fhe-with-zama-fhevm) - Nov 2024
 
 ## Video tutorials
 
@@ -49,15 +49,15 @@ The library includes templates for common use cases like tokens and governance, 
 We want to hear from you! Take 1 minute to share your thoughts and helping us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
 {% endhint %}
 
-### Legacy - Not compatible with latest HTTPZ
+### Legacy - Not compatible with latest fhevm
 
-- [Build an Encrypted Wordle Game Onchain using FHE and HTTPZ](https://www.zama.ai/post/build-an-encrypted-wordle-game-onchain-using-fhe-and-zama-fhevm) - February 2024
+- [Build an Encrypted Wordle Game Onchain using FHE and fhevm](https://www.zama.ai/post/build-an-encrypted-wordle-game-onchain-using-fhe-and-zama-fhevm) - February 2024
 - [Programmable Privacy and Onchain Compliance using Homomorphic Encryption](https://www.zama.ai/post/programmable-privacy-and-onchain-compliance-using-homomorphic-encryption) - November 2023
 - [Confidential DAO Voting Using Homomorphic Encryption](https://www.zama.ai/post/confidential-dao-voting-using-homomorphic-encryption) - October 2023
-- [On-chain Blind Auctions Using Homomorphic Encryption and the HTTPZ](https://www.zama.ai/post/on-chain-blind-auctions-using-homomorphic-encryption) - July 2023
-- [Confidential ERC-20 Tokens Using Homomorphic Encryption and the HTTPZ](https://www.zama.ai/post/confidential-erc-20-tokens-using-homomorphic-encryption) - June 2023
-- [Using asynchronous decryption in Solidity contracts with HTTPZ](https://www.zama.ai/post/video-tutorial-using-asynchronous-decryption-in-solidity-contracts-with-fhevm) - April 2024
-- [Accelerate your code testing and get code coverage using HTTPZ mocks](https://www.zama.ai/post/video-tutorial-accelerate-your-code-testing-and-get-code-coverage-using-fhevm-mocks) - January 2024
-- [Use the CMUX operator on HTTPZ](https://www.youtube.com/watch?v=7icM0EOSvU0) - October 2023
-- [\[Video tutorial\] How to Write Confidential Smart Contracts Using HTTPZ](https://www.zama.ai/post/video-tutorial-how-to-write-confidential-smart-contracts-using-zamas-fhevm) - October 2023
+- [On-chain Blind Auctions Using Homomorphic Encryption and the fhevm](https://www.zama.ai/post/on-chain-blind-auctions-using-homomorphic-encryption) - July 2023
+- [Confidential ERC-20 Tokens Using Homomorphic Encryption and the fhevm](https://www.zama.ai/post/confidential-erc-20-tokens-using-homomorphic-encryption) - June 2023
+- [Using asynchronous decryption in Solidity contracts with fhevm](https://www.zama.ai/post/video-tutorial-using-asynchronous-decryption-in-solidity-contracts-with-fhevm) - April 2024
+- [Accelerate your code testing and get code coverage using fhevm mocks](https://www.zama.ai/post/video-tutorial-accelerate-your-code-testing-and-get-code-coverage-using-fhevm-mocks) - January 2024
+- [Use the CMUX operator on fhevm](https://www.youtube.com/watch?v=7icM0EOSvU0) - October 2023
+- [\[Video tutorial\] How to Write Confidential Smart Contracts Using fhevm](https://www.zama.ai/post/video-tutorial-how-to-write-confidential-smart-contracts-using-zamas-fhevm) - October 2023
 - [Workshop during ETHcc: Homomorphic Encryption in the EVM](https://www.youtube.com/watch?v=eivfVykPP8U) - July 2023


### PR DESCRIPTION
Closes #764 

changes also the naming of:
 - `@httpz/sdk` to `@fhevm/sdk` - confirm if this is correct?
 - https://github.com/zama-ai/fhevm to https://github.com/zama-ai/fhevm-solidity
 - all mentions of HTTPZ in the docs to fhevm