### PR TITLE
docs: remove vue template mentions

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -54,7 +54,6 @@
 - [Build a web application](frontend/webapp.md)
 - [Using React.js](https://github.com/zama-ai/fhevm-react-template)
 - [Using Next.js](https://github.com/zama-ai/fhevm-next-template)
-- [Using Vue.js](https://github.com/zama-ai/fhevm-vue-template)
 - [Using Node or Typescript](frontend/node.md)
 - [Using the CLI](frontend/cli.md)
 - [Common webpack errors](frontend/webpack.md)

--- a/docs/frontend/webapp.md
+++ b/docs/frontend/webapp.md
@@ -10,10 +10,6 @@ This document guides you through building a web application using the @fhevm/sdk
 
 You can use [this template](https://github.com/zama-ai/fhevmjs-react-template) to start an application with @fhevm/sdk, using Vite + React + TypeScript.
 
-### VueJS + TypeScript
-
-You can also use [this template](https://github.com/zama-ai/fhevmjs-vue-template) to start an application with @fhevm/sdk, using Vite + Vue + TypeScript.
-
 ### NextJS + Typescript
 
 You can also use [this template](https://github.com/zama-ai/fhevmjs-next-template) to start an application with @fhevm/sdk, using Next + TypeScript.

--- a/docs/getting-started/overview-1/hardhat/5.-interacting-with-the-contract.md
+++ b/docs/getting-started/overview-1/hardhat/5.-interacting-with-the-contract.md
@@ -162,7 +162,6 @@ Use out-of-box templates and frameworks designed for developers to build confide
 
 - [**React.js Template**](https://github.com/zama-ai/fhevm-react-template): Quickly develop FHE-compatible dApps using a clean React.js setup.
 - [**Next.js Template**](https://github.com/zama-ai/fhevm-next-template): Build scalable, server-rendered dApps with FHE integration.
-- [**Vue.js Template**](https://github.com/zama-ai/fhevm-vue-template): Develop responsive and modular dApps with FHE support in Vue.js.
 
 ### 3. Community
 

--- a/docs/getting-started/overview-1/remix/interact.md
+++ b/docs/getting-started/overview-1/remix/interact.md
@@ -127,7 +127,6 @@ Use out-of-box templates and frameworks designed for developers to build confide
 
 - [**React.js Template**](https://github.com/zama-ai/fhevm-react-template): Quickly develop FHE-compatible dApps using a clean React.js setup.
 - [**Next.js Template**](https://github.com/zama-ai/fhevm-next-template): Build scalable, server-rendered dApps with FHE integration.
-- [**Vue.js Template**](https://github.com/zama-ai/fhevm-vue-template): Develop responsive and modular dApps with FHE support in Vue.js.
 
 ### 3. Community
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -14,7 +14,7 @@ The fhevm Protocol provides a **`TFHE` Solidity library** for building confident
 
 #### Frontend development
 
-<table><thead><tr><th width="252">Repository</th><th>Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevmjs/">@fhevm/sdk</a></td><td>JavaScript library for client‐side FHE, enabling encryption, decryption, and data handling.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-react-template">fhevm-react-template</a></td><td>React.js template to quickly spin up FHE‐enabled dApps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-next-template">fhevm-next-template</a></td><td>Next.js template for integrating FHE in server‐side rendered or hybrid web apps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-vue-template">fhevm-vue-template</a></td><td>Vue.js template for creating privacy‐preserving dApps with encrypted data</td></tr></tbody></table>
+<table><thead><tr><th width="252">Repository</th><th>Description</th></tr></thead><tbody><tr><td><a href="https://github.com/zama-ai/fhevmjs/">@fhevm/sdk</a></td><td>JavaScript library for client‐side FHE, enabling encryption, decryption, and data handling.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-react-template">fhevm-react-template</a></td><td>React.js template to quickly spin up FHE‐enabled dApps.</td></tr><tr><td><a href="https://github.com/zama-ai/fhevm-next-template">fhevm-next-template</a></td><td>Next.js template for integrating FHE in server‐side rendered or hybrid web apps.</td></tr></tbody></table>
 
 #### Examples & Resources
 

--- a/docs/references/repositories.md
+++ b/docs/references/repositories.md
@@ -12,7 +12,6 @@ Quickly set up your development environment with these ready-to-use templates:
 | [fhevm-hardhat-template](https://github.com/zama-ai/fhevm-hardhat-template) | Hardhat template for FHE smart contract development |
 | [fhevm-react-template](https://github.com/zama-ai/fhevm-react-template)     | React.js template for building FHE dApps            |
 | [fhevm-next-template](https://github.com/zama-ai/fhevm-next-template)       | Next.js template for FHE-enabled dApps              |
-| [fhevm-vue-template](https://github.com/zama-ai/fhevm-vue-template)         | Vue.js template for developing FHE dApps            |
 
 ## **IDE plugins**
 


### PR DESCRIPTION
Closes: https://github.com/zama-ai/planning-blockchain/issues/621

---

Temporarily removes all mentions of vue template until we can ensure better maintenance of the repository